### PR TITLE
fix(web): load model selection scripts on model pages

### DIFF
--- a/apps/web/src/pages/models-clean.astro
+++ b/apps/web/src/pages/models-clean.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import ClientScriptLoader from '../components/ClientScriptLoader.tsx';
 ---
 
 <Layout title="Financial Models" description="Comprehensive financial analysis tools with AI-powered insights" canonical={Astro.url.href}>
@@ -390,8 +391,5 @@ import Layout from '../layouts/Layout.astro';
 
     <!-- VS Code Style Chat Panel -->
   </div>
-
-  <script type="module">
-    import '../scripts/models.client.ts';
-  </script>
+  <ClientScriptLoader client:load slot="pageScripts" name="models" />
 </Layout>

--- a/apps/web/src/pages/models/business.astro
+++ b/apps/web/src/pages/models/business.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import ClientScriptLoader from '../../components/ClientScriptLoader.tsx';
 
 const keywords = "business finance, commercial real estate, lease analysis, EBITDA forecasting, equipment lease calculator, NPV analysis, cash flow analysis, business loan calculator, financial modeling tools";
 const enhancedDescription = "Comprehensive business finance modeling tools for commercial real estate, lease analysis, EBITDA forecasting, and cash flow projections. Professional-grade calculators for equipment leasing, commercial property loans, and financial planning.";
@@ -589,7 +590,5 @@ const faqSchema = {
     </div>
   </div>
 
-  <script type="module">
-    import '../../scripts/models.client.ts';
-  </script>
+  <ClientScriptLoader client:load slot="pageScripts" name="models" />
 </Layout>

--- a/apps/web/src/pages/models/personal.astro
+++ b/apps/web/src/pages/models/personal.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import ClientScriptLoader from '../../components/ClientScriptLoader.tsx';
 
 const keywords = "personal finance, mortgage calculator, retirement planning, auto loan calculator, debt payoff, savings goal calculator, student loan calculator, budget planner, amortization calculator";
 const enhancedDescription = "Free personal finance calculators and planning tools for mortgages, retirement, auto loans, debt payoff, savings goals, student loans, and budgeting. Professional-grade financial modeling made simple.";
@@ -592,8 +593,5 @@ const faqSchema = {
       </div>
     </div>
   </div>
-
-  <script type="module">
-    import '../../scripts/models.client.ts';
-  </script>
+  <ClientScriptLoader client:load slot="pageScripts" name="models" />
 </Layout>


### PR DESCRIPTION
## Summary
- load the models page client logic through ClientScriptLoader on personal, business, and clean variants
- remove redundant inline module imports that double-executed the selection script

## Testing
- pnpm typecheck && pnpm lint && pnpm test