### PR TITLE
ci(actions): remove scheduled analysis monitors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,6 @@ name: Coverage
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 3 * * *'
 
 concurrency:
   group: coverage-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/monitor-r2-quotas.yml
+++ b/.github/workflows/monitor-r2-quotas.yml
@@ -1,8 +1,6 @@
 name: Monitor R2 Quotas (prod)
 
 on:
-  schedule:
-    - cron: '30 8 * * *' # daily at 08:30 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/monitor-workers-health.yml
+++ b/.github/workflows/monitor-workers-health.yml
@@ -1,8 +1,6 @@
 name: Monitor Workers Health (prod)
 
 on:
-  schedule:
-    - cron: '0 8 * * *' # daily at 08:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -2,8 +2,6 @@ name: Mutation Tests (Analysis)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * *'
 
 concurrency:
   group: mutation-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- remove scheduled coverage, mutation, worker-health, and quota monitor runs
- keep the workflows available via manual dispatch

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>