### PR TITLE
build: remove ui prepare hook

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,8 +22,7 @@
     "format:check": "prettier --check src",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config ./vitest.config.mjs",
-    "test:ui": "vitest --ui",
-    "prepare": "tsc -p tsconfig.json"
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "@financial-analysis/analysis": "workspace:*",


### PR DESCRIPTION
## Summary\n- remove the install-time TypeScript build from packages/ui\n- prevent pnpm install in GitHub Actions from failing before the explicit build steps run\n- unblock Cloudflare preview and production deploy workflows\n\n## Validation\n- pnpm --filter @financial-analysis/ui typecheck\n- pnpm --filter @financial-analysis/ui test