### PR TITLE
ci: build analysis before ui in deploy workflows

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build UI package (for Astro build)
-        run: pnpm --filter @financial-analysis/ui run build
+      - name: Build analysis and UI packages (for Astro build)
+        run: |
+          pnpm --filter @financial-analysis/analysis run build
+          pnpm --filter @financial-analysis/ui run build
 
       - name: Build Astro site
         working-directory: apps/web

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,8 +44,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build UI package (for Astro build)
-        run: pnpm --filter @financial-analysis/ui run build
+      - name: Build analysis and UI packages (for Astro build)
+        run: |
+          pnpm --filter @financial-analysis/analysis run build
+          pnpm --filter @financial-analysis/ui run build
 
       - name: Build Astro site
         working-directory: apps/web


### PR DESCRIPTION
## Summary\n- build the analysis package before the UI package in deploy-preview and deploy-production\n- align the clean-runner build order with the workspace dependency graph\n- unblock Cloudflare preview and production deploy jobs\n\n## Validation\n- git commit hook run: pnpm lint\n- git commit hook run: pnpm typecheck