### PR TITLE
ci: use node 24 for cloudflare deploys

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary\n- update Cloudflare deploy workflows to Node 24\n- satisfy Wrangler's current runtime requirement\n- remove the remaining workflow-side blocker before live deploy auth\n\n## Validation\n- git commit hook run: pnpm lint\n- git commit hook run: pnpm typecheck