### PR TITLE
chore: add MIT license on main

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
+MIT License
 
+Copyright (c) 2026 Blake Oxford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "financial-analysis",
   "version": "0.1.1",
   "description": "Financial analysis tooling with LLM integration via MCP",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "build": "pnpm --recursive run build",


### PR DESCRIPTION
## Summary
Adds the MIT `LICENSE` and `package.json` license field to `main` so GitHub detects the license on the default branch.

## Test plan
- [x] Pre-commit hooks passed (lint + typecheck)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds licensing metadata (`LICENSE` file and `package.json` `license` field) with no runtime or behavior changes.
> 
> **Overview**
> Adds an MIT `LICENSE` file and sets `"license": "MIT"` in `package.json` so the repository’s licensing is explicitly declared and detectable by tooling (e.g., GitHub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1e93a44f47785bc6a4729188eefb2a3e071664. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added MIT License file and updated project metadata to clarify licensing terms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->