### PR TITLE
chore: Finder duplicate cleanup and stricter duplicate detection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to the `financial-analysis` project!
 ### Prerequisites
 
 - Node.js 22+ (see `.nvmrc`)
-- pnpm 8+ (<https://pnpm.io/installation>)
+- pnpm 10+ (see `packageManager` in root `package.json`)
 - Cloudflare account (for Workers deployment)
 - Git
 
@@ -120,6 +120,14 @@ If you see a build loop, ensure `.astro/` and `dist/` are ignored (see `apps/web
 - **Astro + Tailwind:** Use Astro for pages/layout, Tailwind for styling
 - **Cloudflare stack:** Use Workers for APIs, R2 for file storage, D1 for relational data, KV for sessions, Queues for long tasks
 - **Deterministic math:** Financial calculations must be pure, testable TypeScript functions
+
+### Duplicate files
+
+Never commit duplicate copies. The repo enforces this via `pnpm run check:duplicates` (also runs on pre-commit and PRs).
+
+- **Playwright specs** must live under feature folders (`tests/chat/`, `tests/nav/`, etc.) with unique basenames.
+- **Shared test helpers** belong in `apps/web/tests/_shared/` (not `tests/utils/`).
+- **macOS Finder copies** (`file 2.md`, `package 2`, etc.) must be deleted — run `pnpm run clean:finder-duplicates` or `pnpm run clean:finder-duplicates -- --node-modules` if duplicates appear under `node_modules/`.
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ pnpm --filter @financial-analysis/web exec node scripts/test-runner.mjs --playwr
 
 Notes:
 
-- `pnpm run check:duplicates` fails on macOS Finder copies, identical test files, and duplicate Playwright spec basenames.
+- `pnpm run check:duplicates` fails on macOS Finder copies, identical test files, and duplicate Playwright spec basenames. Use `pnpm run clean:finder-duplicates` to remove Finder copies.
 - `test:layout` (included in `check:duplicates`) enforces the Playwright tests layout under `apps/web/tests`.
 - `typecheck:tests` statically checks Playwright specs/helpers before browser runs.
 - `test:coverage` currently gates the web logic/framework modules that already have strong Vitest protection; expand that scope as more app logic gets dedicated tests.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "format:check": "pnpm --recursive exec prettier --check .",
     "typecheck": "pnpm --recursive run typecheck",
     "check:duplicates": "node scripts/check-repo-duplicates.mjs",
+    "clean:finder-duplicates": "node scripts/clean-finder-duplicates.mjs",
     "changeset": "changeset",
     "clean": "pnpm --recursive run clean",
     "smoke": "node scripts/smoke.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         specifier: ^8.3.0
         version: 8.3.0
       vite:
-        specifier: ^8.0.13
+        specifier: '>=8.0.13'
         version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.6
@@ -127,7 +127,7 @@ importers:
         specifier: ^6.0.184
         version: 6.0.184(zod@4.4.3)
       astro:
-        specifier: ^6.3.3
+        specifier: '>=6.1.10'
         version: 6.3.3(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
       lucide-react:
         specifier: ^1.16.0
@@ -188,7 +188,7 @@ importers:
         specifier: ^20.9.0
         version: 20.9.0
       postcss:
-        specifier: ^8.5.14
+        specifier: '>=8.5.14'
         version: 8.5.14
       prettier:
         specifier: ^3.8.3
@@ -243,7 +243,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.13
+        specifier: '>=8.0.13'
         version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.6
@@ -380,7 +380,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.13
+        specifier: '>=8.0.13'
         version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.6
@@ -8034,7 +8034,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.6':
     dependencies:

--- a/scripts/check-repo-duplicates.mjs
+++ b/scripts/check-repo-duplicates.mjs
@@ -10,7 +10,6 @@ const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 const SKIP_DIRS = new Set([
   '.git',
-  'node_modules',
   'dist',
   'build',
   '.astro',
@@ -24,28 +23,43 @@ const SKIP_DIRS = new Set([
 /** macOS Finder duplicate suffix: "file 2.md", ".nvmrc 2", etc. */
 const FINDER_DUPLICATE = / 2(\.[^./]+)?$/;
 
-function walkFiles(dir, files = []) {
+function walkFinderPaths(dir, paths = [], { skipNodeModules = true } = {}) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (SKIP_DIRS.has(entry.name)) continue;
+    if (skipNodeModules && entry.name === 'node_modules') continue;
+    const fullPath = join(dir, entry.name);
+    if (FINDER_DUPLICATE.test(entry.name)) {
+      paths.push(fullPath);
+    }
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      walkFinderPaths(fullPath, paths, { skipNodeModules });
+    }
+  }
+  return paths;
+}
+
+export function findMacOSFinderDuplicates(rootDir = REPO_ROOT, { skipNodeModules = true } = {}) {
+  return walkFinderPaths(rootDir, [], { skipNodeModules }).map((file) => relative(rootDir, file));
+}
+
+export function findNodeModulesFinderDuplicates(rootDir = REPO_ROOT) {
+  return findMacOSFinderDuplicates(rootDir, { skipNodeModules: false }).filter((path) =>
+    path.split(/[/\\]/).includes('node_modules')
+  );
+}
+
+function walkFiles(dir, files = [], { skipNodeModules = true } = {}) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    if (skipNodeModules && entry.name === 'node_modules') continue;
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
-      walkFiles(fullPath, files);
+      walkFiles(fullPath, files, { skipNodeModules });
       continue;
     }
     files.push(fullPath);
   }
   return files;
-}
-
-export function findMacOSFinderDuplicates(rootDir = REPO_ROOT) {
-  const hits = [];
-  for (const file of walkFiles(rootDir)) {
-    const name = basename(file);
-    if (FINDER_DUPLICATE.test(name)) {
-      hits.push(relative(rootDir, file));
-    }
-  }
-  return hits;
 }
 
 export function findIdenticalFiles(rootDir, { include = () => true } = {}) {
@@ -80,6 +94,15 @@ function main() {
     for (const path of finderDuplicates) {
       console.error(`  - ${path}`);
     }
+    console.error('\nRun: pnpm run clean:finder-duplicates');
+  }
+
+  const nodeModulesDuplicates = findNodeModulesFinderDuplicates();
+  if (nodeModulesDuplicates.length > 0) {
+    console.warn(
+      `Warning: ${nodeModulesDuplicates.length} macOS Finder duplicate(s) under node_modules/ (not blocking).`
+    );
+    console.warn('Run: pnpm run clean:finder-duplicates -- --node-modules && pnpm install');
   }
 
   const webTestRoot = join(REPO_ROOT, 'apps/web/tests');

--- a/scripts/clean-finder-duplicates.mjs
+++ b/scripts/clean-finder-duplicates.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { readdirSync, rmSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { findMacOSFinderDuplicates } from './check-repo-duplicates.mjs';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const SKIP_DIRS = new Set([
+  '.git',
+  // node_modules is traversed only when --node-modules is passed (see skipNodeModules flag)
+  'dist',
+  'build',
+  '.astro',
+  '.wrangler',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  '.pnpm-store',
+]);
+
+/** macOS Finder duplicate suffix: "file 2.md", "package 2", etc. */
+const FINDER_DUPLICATE = / 2(\.[^./]+)?$/;
+
+function walkFinderDuplicates(rootDir, { includeNodeModules = false } = {}) {
+  const hits = [];
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!includeNodeModules && entry.name === 'node_modules') continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+
+      const fullPath = join(dir, entry.name);
+      if (FINDER_DUPLICATE.test(entry.name)) {
+        hits.push(fullPath);
+      }
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        stack.push(fullPath);
+      }
+    }
+  }
+
+  return hits;
+}
+
+function main() {
+  const includeNodeModules = process.argv.includes('--node-modules');
+  const dryRun = process.argv.includes('--dry-run');
+
+  const targets = includeNodeModules
+    ? walkFinderDuplicates(REPO_ROOT, { includeNodeModules: true })
+    : findMacOSFinderDuplicates(REPO_ROOT).map((rel) => join(REPO_ROOT, rel));
+
+  if (targets.length === 0) {
+    console.log('No macOS Finder duplicate files found.');
+    return;
+  }
+
+  console.log(
+    dryRun ? 'Would delete:' : 'Deleting:',
+    includeNodeModules ? '(including node_modules)' : '(repository files only)'
+  );
+
+  const orderedTargets = [...targets].sort((a, b) => b.length - a.length);
+
+  for (const fullPath of orderedTargets) {
+    const rel = relative(REPO_ROOT, fullPath);
+    if (dryRun) {
+      console.log(`  - ${rel}`);
+      continue;
+    }
+    try {
+      rmSync(fullPath, { force: true, recursive: true });
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        continue;
+      }
+      throw error;
+    }
+    console.log(`  - ${rel}`);
+  }
+
+  if (!dryRun && includeNodeModules) {
+    console.log('\nRun `pnpm install` if you removed duplicate packages under node_modules.');
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Fix duplicate scanner: `node_modules` was incorrectly in `SKIP_DIRS`, so Finder copies (files, dirs, symlinks) were never detected
- Add `pnpm run clean:finder-duplicates` (and `-- --node-modules` for dependency trees)
- Warn (non-blocking) when `node_modules` contains Finder duplicates, with remediation command
- Add `.npmrc` with `engine-strict=true` for Node 22+
- Document duplicate policy in CONTRIBUTING

## Test plan

- [x] `pnpm run check:duplicates`
- [x] `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to repo tooling/docs and Node/pnpm enforcement, with no production runtime logic affected. Main risk is stricter duplicate detection causing new CI failures or accidental deletions if the cleanup script is misused (especially with `--node-modules`).
> 
> **Overview**
> Tightens repo duplicate-file enforcement by fixing `check:duplicates` to correctly detect macOS Finder “` 2`” copies (optionally skipping `node_modules`) and adding a non-blocking warning path for duplicates found under `node_modules` with a recommended remediation command.
> 
> Adds `pnpm run clean:finder-duplicates` (`scripts/clean-finder-duplicates.mjs`) to delete Finder duplicate copies (supports `--dry-run` and optional `--node-modules`), and documents the duplicate policy/removal workflow in `CONTRIBUTING.md`/`README.md`. Also adds `.npmrc` `engine-strict=true` and updates tooling/version constraints in the lockfile to align with stricter engine/package requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ffd42e64970c1a5e26b3342a61a95c5387903b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced strict Node version checking in npm configuration.
  * Added development cleanup utility for macOS Finder duplicate files.

* **Documentation**
  * Updated development prerequisites to require pnpm 10+.
  * Enhanced contributor guidelines with duplicate file handling standards.
  * Updated macOS testing remediation instructions in README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->