### PR TITLE
chore: allow pnpm build scripts and add local setup workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check for duplicate files
+        run: pnpm run check:duplicates
+
       - name: Run smoke tests
         run: pnpm test:smoke
 
@@ -57,6 +60,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check for duplicate files
+        run: pnpm run check:duplicates
 
       - name: Typecheck
         run: pnpm typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ Thank you for your interest in contributing to the `financial-analysis` project!
    pnpm install
    ```
 
+   If you see ignored build-script warnings, stale `node_modules`, or macOS Finder duplicates (`package 2`), run a clean reinstall:
+
+   ```bash
+   pnpm run setup:local
+   ```
+
+   That removes all workspace `node_modules`, reinstalls, and installs the Playwright Chromium browser for e2e tests.
+
 3. Set up Cloudflare Workers:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "typecheck": "pnpm --recursive run typecheck",
     "check:duplicates": "node scripts/check-repo-duplicates.mjs",
     "clean:finder-duplicates": "node scripts/clean-finder-duplicates.mjs",
+    "reinstall": "rm -rf node_modules apps/*/node_modules packages/*/node_modules workers/*/node_modules && pnpm install",
+    "setup:local": "pnpm run reinstall && pnpm --filter @financial-analysis/web exec playwright install chromium",
     "changeset": "changeset",
     "clean": "pnpm --recursive run clean",
     "smoke": "node scripts/smoke.mjs",
@@ -70,6 +72,13 @@
   },
   "packageManager": "pnpm@10.17.0",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js-pure",
+      "esbuild",
+      "lefthook",
+      "sharp",
+      "workerd"
+    ],
     "overrides": {
       "js-yaml": ">=4.1.1",
       "astro": ">=6.1.10",


### PR DESCRIPTION
## Summary

- Add `pnpm.onlyBuiltDependencies` for esbuild, lefthook, sharp, workerd, core-js-pure (no interactive `approve-builds` after reinstall)
- Add `pnpm run reinstall` and `pnpm run setup:local` (reinstall + Playwright Chromium)
- Run `check:duplicates` in CI workflow jobs
- Document clean setup in CONTRIBUTING

## Verified locally

- Fresh reinstall with no ignored build-script warning
- Playwright smoke e2e: 9/9 pass
- `pnpm run check:duplicates` + `pnpm audit` clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: modifies CI workflow and pnpm install behavior (`onlyBuiltDependencies`) plus adds a destructive `reinstall` script, which could affect dependency installation and pipeline stability if misconfigured.
> 
> **Overview**
> Adds a `check:duplicates` gate to CI (both smoke and build/test jobs) so Finder-style duplicates, identical `apps/web/tests` files, and the web `test:layout` check fail PRs earlier.
> 
> Introduces local setup helpers (`reinstall`, `setup:local`) and documents them in `CONTRIBUTING.md` for clean reinstalls and Playwright Chromium setup. Updates root `package.json` to whitelist specific packages via `pnpm.onlyBuiltDependencies` to avoid interactive build-script approval prompts during installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da673416f4cb9c89b3eb8ff29e3b48cbbd0bf7fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup guide with troubleshooting tips for dependency and build issues.

* **Chores**
  * Enhanced CI pipeline to check for duplicate dependencies.
  * Added automated scripts for clean local environment setup and dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->