### PR TITLE
chore: sync dev with main (#239)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,9 @@
 name: CI Pipeline
 
 on:
+  # Main-only: PR/dev gates run via ci.yml, pull-request.yml, and e2e-web.yml
   push:
-    branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch:
 
 # Default, least-privilege permissions for all jobs; override per-job when needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,8 @@ jobs:
       - name: Check for duplicate files
         run: pnpm run check:duplicates
 
-      - name: Build shared packages
-        run: pnpm run build:libs
-
       - name: Typecheck
-        run: pnpm typecheck
+        run: pnpm run typecheck
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,17 @@
 name: Coverage
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/analysis/**'
+      - 'packages/ui/**'
+      - 'apps/web/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/coverage.yml'
+  schedule:
+    # Weekly coverage report (Mon 06:00 UTC)
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +39,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm run build:libs
 
       - name: Run analysis coverage
         run: pnpm --filter @financial-analysis/analysis run test:coverage
@@ -68,6 +82,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm run build:libs
 
       - name: Run web coverage
         run: pnpm --filter @financial-analysis/web run test:coverage

--- a/.github/workflows/monitor-r2-quotas.yml
+++ b/.github/workflows/monitor-r2-quotas.yml
@@ -1,6 +1,9 @@
 name: Monitor R2 Quotas (prod)
 
 on:
+  schedule:
+    # Daily R2 quota check (09:30 UTC)
+    - cron: '30 9 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/monitor-workers-health.yml
+++ b/.github/workflows/monitor-workers-health.yml
@@ -1,6 +1,9 @@
 name: Monitor Workers Health (prod)
 
 on:
+  schedule:
+    # Daily production worker health (09:00 UTC)
+    - cron: '0 9 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,6 +1,9 @@
 name: Mutation Tests (Analysis)
 
 on:
+  schedule:
+    # Monthly mutation testing (1st of month, 08:00 UTC)
+    - cron: '0 8 1 * *'
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +31,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm run build:libs
 
       - name: Run mutation tests (analysis)
         run: pnpm --filter @financial-analysis/analysis test:mutation

--- a/README.md
+++ b/README.md
@@ -376,14 +376,28 @@ cd workers/web && pnpm run build                    # dry-run deploy
 
 ### CI and Preview Deploys
 
-GitHub Actions run on pushes and PRs to `main` and `dev`:
+GitHub Actions:
 
-- `.github/workflows/ci.yml` — API smoke tests, typecheck, lint, format, audit, unit tests, Playwright site smoke
-- `.github/workflows/ci-cd.yml` — Quality gate, workspace tests, production build artifacts, `pnpm audit`, CodeQL
-- `.github/workflows/pull-request.yml` — Duplicate-file check, dependency review, secret scan
-- `.github/workflows/e2e-web.yml` — Cross-browser smoke matrix on web-related PRs; weekly extended smoke; manual full/matrix/flake lanes
+**On every push/PR to `main` and `dev`**
 
-Manual workflows (`workflow_dispatch`): `e2e-web`, `coverage`, `mutation`, `deploy-preview`, `deploy-production`, worker monitors.
+- `.github/workflows/ci.yml` — API smoke, typecheck, lint, format, audit, unit tests, Playwright site smoke
+- `.github/workflows/pull-request.yml` (PRs only) — Duplicate-file check, dependency review, secret scan
+- `.github/workflows/e2e-web.yml` (web-related PRs) — Cross-browser smoke matrix
+
+**On push to `main` only**
+
+- `.github/workflows/ci-cd.yml` — Build artifacts, CodeQL, security audit (avoids duplicating PR gates)
+
+**Scheduled**
+
+- `e2e-web` — Weekly extended smoke (Mon 12:00 UTC)
+- `coverage` — Weekly coverage (Mon 06:00 UTC); also on `main` when analysis/web change
+- `mutation` — Monthly analysis mutation tests (1st of month)
+- `monitor-workers-health` / `monitor-r2-quotas` — Daily production checks (skip gracefully without secrets)
+
+**Manual (`workflow_dispatch`)**
+
+`e2e-web` (full/flake lanes), `deploy-preview`, `deploy-production`, and all of the above.
 
 - `.github/workflows/deploy-preview.yml` — Builds the site and deploys both Workers to Cloudflare preview. Injects `COMMIT_SHA` so `/version` returns the current commit.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,8 @@ pre-commit:
   commands:
     duplicates:
       run: pnpm run check:duplicates
+    format:
+      run: pnpm run format:check
     lint:
       run: pnpm lint
     typecheck:


### PR DESCRIPTION
Syncs dev after #239.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/workflow configuration and local git hooks; main risk is altered GitHub Actions trigger behavior (e.g., `ci-cd` now runs only on `main`) causing missed or duplicated checks if misconfigured.
> 
> **Overview**
> Refactors GitHub Actions triggers so `ci-cd.yml` runs on *push to `main` only* (removing PR/dev execution) while adding scheduled runs for `coverage`, `mutation`, and production monitor workflows.
> 
> Updates quality workflows to build shared libs before coverage/mutation runs, normalizes the `typecheck` step invocation, adds a pre-commit `format:check` via `lefthook.yml`, and refreshes the README’s CI matrix documentation to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2943cd80e48c4c6b9b1527b4745831524a25abc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->