### PR TITLE
chore: sync dev with main (#241)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -116,11 +116,14 @@ Closes #
 
 ## Checklist
 
+- [ ] ✅ `pnpm run verify` passes locally
 - [ ] ✅ Code follows project conventions (TypeScript, ESLint, Prettier)
 - [ ] ✅ Commit messages are clear and descriptive
-- [ ] ✅ Branch is up to date with main
+- [ ] ✅ Branch is up to date with `main`
 - [ ] ✅ No merge conflicts
 - [ ] ✅ Ready for review
+
+<!-- Optional: add label `deploy-preview` to trigger Cloudflare preview deploy -->
 
 ## Additional Notes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,10 @@ Daily workflows (use pnpm)
 
 - Dev all (recommended): `pnpm dev` runs `scripts/dev-all.mjs` → builds `apps/web`, starts `@financial-analysis/web-worker` on 8788, then API on 8787.
 - Individual dev: `pnpm --filter @financial-analysis/api dev` and `pnpm --filter @financial-analysis/web-worker dev` (ensure `apps/web` built first).
-- Typecheck/lint/test (monorepo): `pnpm typecheck && pnpm lint && pnpm test`.
+- CI gate (monorepo): `pnpm run verify` (duplicates, typecheck, lint, format, tests).
+- Typecheck/lint/test only: `pnpm typecheck && pnpm lint && pnpm test` (`pretypecheck` runs `build:libs`).
 - Web app prebuild: `apps/web/package.json` runs `prebuild` to rebuild `@financial-analysis/ui` and clear `node_modules/.vite` to avoid stale chunks.
-- Playwright e2e (web): from `apps/web` run `pnpm test:e2e`; HMR stability: `pnpm test:e2e:hmr` (uses `playwright.dev.config.ts`).
+- Playwright e2e (web): specs live under `apps/web/tests/{chat,nav,site,...}/`; smoke: `pnpm test:e2e:smoke`; HMR-only: `pnpm test:e2e:hmr`.
 
 API and contracts (concrete patterns)
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,8 @@
 name: Deploy Preview (API + Web)
 
 on:
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +14,9 @@ permissions:
 
 jobs:
   deploy:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'deploy-preview')
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -31,17 +36,15 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build analysis and UI packages (for Astro build)
-        run: |
-          pnpm --filter @financial-analysis/analysis run build
-          pnpm --filter @financial-analysis/ui run build
+      - name: Build shared packages
+        run: pnpm run build:libs
 
       - name: Build Astro site
         working-directory: apps/web

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,17 +37,15 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build analysis and UI packages (for Astro build)
-        run: |
-          pnpm --filter @financial-analysis/analysis run build
-          pnpm --filter @financial-analysis/ui run build
+      - name: Build shared packages
+        run: pnpm run build:libs
 
       - name: Build Astro site
         working-directory: apps/web

--- a/AGENT.md
+++ b/AGENT.md
@@ -59,9 +59,11 @@ This file defines how AI coding assistants should contribute to this repository.
 
 ## Testing & CI
 
-- Engines: 100% covered with unit tests (edge cases: escalations, free rent overlaps, extra payments).
-- End-to-end happy path tests with Playwright.
-- GitHub Actions: lint, typecheck, unit tests, preview deploy.
+- Engines: unit tests with Vitest (edge cases: escalations, free rent overlaps, extra payments).
+- Playwright e2e under `apps/web/tests/{chat,nav,site,...}/` (shared helpers in `tests/_shared/`).
+- Local gate: `pnpm run verify` (duplicates, typecheck, lint, format, tests). Hooks run format/lint/typecheck on commit and verify on push.
+- CI on PR/`dev`: `ci.yml`, `pull-request.yml`, `e2e-web` (web paths). `ci-cd.yml` runs on `main` push only (build artifacts, CodeQL).
+- Preview deploy: add label `deploy-preview` on a PR or run `deploy-preview` workflow manually.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+Guidance for AI coding assistants working in this repository.
+
+**Primary reference:** [AGENT.md](./AGENT.md) (coding standards, structure, security).
+
+**Contributor workflow:** [CONTRIBUTING.md](./CONTRIBUTING.md) (setup, hooks, PR process).
+
+## Quick commands
+
+```bash
+pnpm run setup:local   # clean install + Playwright chromium (first time / broken node_modules)
+pnpm run verify        # CI gate: duplicates, typecheck, lint, format, tests
+pnpm run build:libs    # build @financial-analysis/analysis + ui (runs before typecheck via pretypecheck)
+pnpm run dev           # Astro build + web worker (8788) + API (8787)
+```
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `apps/web` | Astro frontend; Playwright tests under `tests/{chat,nav,site,...}/` |
+| `workers/api` | Cloudflare API, MCP, chat, OpenAPI |
+| `workers/web` | Static asset worker for built Astro site |
+| `packages/analysis` | Deterministic financial engines (build before consumers typecheck) |
+| `packages/ui` | Shared React components |
+| `packages/tools` | MCP tool handlers |
+
+## CI (do not duplicate locally)
+
+- **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web` (web paths)
+- **`main` push only:** `ci-cd.yml` (artifacts, CodeQL)
+- **Never commit:** Finder duplicates (`file 2`), flat Playwright specs, or `tests/utils/nav.ts` (use `tests/_shared/`)
+
+## Before opening a PR
+
+1. `pnpm run verify`
+2. No secrets in diff
+3. Engines: pure functions + Vitest tests in `packages/analysis`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,10 +189,10 @@ Report vulnerabilities privately — see [SECURITY.md](./SECURITY.md). Do not op
 
 ## Testing
 
-- Engines: 100% covered with unit tests (edge cases: escalations, free rent overlaps, extra payments)
-- End-to-end happy path tests with Playwright
-- Run tests locally: `pnpm test`
-- GitHub Actions: lint, typecheck, unit tests, preview deploy
+- Engines: unit tests with Vitest (edge cases: escalations, free rent overlaps, extra payments)
+- Playwright e2e under `apps/web/tests/` (see `apps/web/scripts/check-test-layout.mjs` for layout rules)
+- Run full local gate: `pnpm run verify`
+- Preview deploy: add the `deploy-preview` label on your PR (requires repo secrets) or run the workflow manually
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -395,9 +395,11 @@ GitHub Actions:
 - `mutation` — Monthly analysis mutation tests (1st of month)
 - `monitor-workers-health` / `monitor-r2-quotas` — Daily production checks (skip gracefully without secrets)
 
-**Manual (`workflow_dispatch`)**
+**Manual / on-demand**
 
-`e2e-web` (full/flake lanes), `deploy-preview`, `deploy-production`, and all of the above.
+- `deploy-preview` — manual, or add label **`deploy-preview`** on a PR
+- `deploy-production` — manual from `main` with confirmation
+- `e2e-web` (full/flake lanes) and all scheduled jobs above
 
 - `.github/workflows/deploy-preview.yml` — Builds the site and deploys both Workers to Cloudflare preview. Injects `COMMIT_SHA` so `/version` returns the current commit.
 


### PR DESCRIPTION
Syncs dev after #241.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions deployment behavior (preview deploy now gated by PR label) and updates the Node version used for production/preview deploys, which could affect build/deploy reliability.
> 
> **Overview**
> **Updates CI/CD and contributor docs around deploys and verification.** Preview deploys now run *only* on manual dispatch or when a PR is labeled `deploy-preview`, and both preview/production deploy workflows switch to Node `22` and use `pnpm run build:libs` for shared package builds.
> 
> Documentation and templates are aligned to these workflows: the PR template and multiple docs now call out `pnpm run verify`, the `deploy-preview` label trigger, and the canonical Playwright test layout. A new `AGENTS.md` is added as a quick-reference entry point for AI assistants (pointing to `AGENT.md`/`CONTRIBUTING.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285cb3ad0c70cee4ab3fa6c673404ce1e8630eec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->