### PR TITLE
chore(ci): add setup-monorepo composite and streamline CI

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,0 +1,29 @@
+name: Setup monorepo
+description: Install pnpm, Node.js, and workspace dependencies for this repository
+inputs:
+  node-version:
+    description: Node.js version
+    required: false
+    default: '22'
+  install-args:
+    description: Arguments passed to pnpm install
+    required: false
+    default: '--frozen-lockfile'
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        version: 10.17.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install ${{ inputs.install-args }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,20 +27,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
         run: pnpm run check:duplicates
@@ -64,20 +52,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -96,20 +72,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -148,20 +112,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Run security audit
         run: pnpm audit --audit-level moderate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,34 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  smoke-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for duplicate files
-        run: pnpm run check:duplicates
-
-      - name: Run smoke tests
-        run: pnpm test:smoke
-
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -50,23 +22,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
         run: pnpm run check:duplicates
+
+      - name: Run API smoke tests
+        run: pnpm test:smoke
 
       - name: Typecheck
         run: pnpm run typecheck

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -28,20 +28,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,20 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,20 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
         run: pnpm run check:duplicates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -16,19 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Create Release PR with Changesets
         uses: changesets/action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Version and changelog (Changesets)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 
 ## CI (do not duplicate locally)
 
+- Workflows use `.github/actions/setup-monorepo` for pnpm + Node 22 + install
 - **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web` (web paths)
 - **`main` push only:** `ci-cd.yml` (artifacts, CodeQL)
 - **Never commit:** Finder duplicates (`file 2`), flat Playwright specs, or `tests/utils/nav.ts` (use `tests/_shared/`)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ GitHub Actions:
 
 **On every push/PR to `main` and `dev`**
 
-- `.github/workflows/ci.yml` — API smoke, typecheck, lint, format, audit, unit tests, Playwright site smoke
+- `.github/workflows/ci.yml` — Single job: duplicates, API smoke, typecheck, lint, format, audit, unit tests, Playwright site smoke
 - `.github/workflows/pull-request.yml` (PRs only) — Duplicate-file check, dependency review, secret scan
 - `.github/workflows/e2e-web.yml` (web-related PRs) — Cross-browser smoke matrix
 


### PR DESCRIPTION
## Summary
- Adds `.github/actions/setup-monorepo` (pnpm 10.17, Node 22, frozen install)
- Merges `smoke-tests` into single `build-and-test` CI job (fewer duplicate installs/checks)
- Adopts composite in ci, ci-cd, pull-request, deploy, and release workflows
- Runs Changesets **release** workflow on `main` pushes (still manual via dispatch)

## Test plan
- [x] `pnpm run verify` locally
- [ ] CI passes with composite action from repo path

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions wiring and job structure, with primary risk being CI/release behavior changes if the composite path or triggers are misconfigured.
> 
> **Overview**
> Adds a new composite GitHub Action, `.github/actions/setup-monorepo`, to standardize **pnpm 10.17.0 + Node 22 + `pnpm install`** setup across workflows.
> 
> Refactors `ci.yml`, `ci-cd.yml`, deploy, PR-check, and release workflows to use the composite action instead of duplicating setup steps, and simplifies `ci.yml` by removing the separate `smoke-tests` job in favor of a single `build-and-test` job that includes the smoke test step.
> 
> Updates `release.yml` to run on pushes to `main` (in addition to manual dispatch) and refreshes CI documentation in `AGENTS.md`/`README.md` to match the new workflow structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eec4c24415a7b56ddbd666c1ac10a2287b7bab3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated monorepo setup (pnpm, Node.js, dependencies) into a reusable GitHub Action.
  * Refactored CI/CD workflows to use the shared action, eliminating duplicate configuration.
  * Updated documentation reflecting the streamlined workflow structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->