### PR TITLE
chore: sync dev with main (#245)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/chatmodes/**'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'SECURITY.md'
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/chatmodes/**'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'SECURITY.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
       - 'apps/web/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/coverage.yml'
+      - '.github/actions/**'
   schedule:
     # Weekly coverage report (Mon 06:00 UTC)
     - cron: '0 6 * * 1'
@@ -25,20 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -68,20 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/analysis/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/e2e-web.yml'
+      - '.github/actions/**'
   schedule:
     # Weekly extended web smoke (Mon 12:00 UTC)
     - cron: '0 12 * * 1'
@@ -61,20 +62,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -111,20 +100,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -165,20 +142,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs
@@ -219,20 +184,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,20 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.17.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
 
       - name: Build shared packages
         run: pnpm run build:libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ Report vulnerabilities privately — see [SECURITY.md](./SECURITY.md). Do not op
    - Updated documentation if needed
 
 2. PRs require:
-   - Passing CI checks
+   - Passing CI checks (doc-only PRs that change only `*.md` / `docs/` skip the main `ci.yml` job)
    - At least one review
    - No merge conflicts
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ GitHub Actions:
 
 **On every push/PR to `main` and `dev`**
 
-- `.github/workflows/ci.yml` — Single job: duplicates, API smoke, typecheck, lint, format, audit, unit tests, Playwright site smoke
+- `.github/workflows/ci.yml` — Single job: duplicates, API smoke, typecheck, lint, format, audit, unit tests, Playwright site smoke (skipped for doc-only changes)
 - `.github/workflows/pull-request.yml` (PRs only) — Duplicate-file check, dependency review, secret scan
 - `.github/workflows/e2e-web.yml` (web-related PRs) — Cross-browser smoke matrix
 


### PR DESCRIPTION
Syncs dev after #245.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes can alter which commits get validated and how jobs are provisioned, potentially causing missed CI runs or environment drift if the shared setup action is incorrect.
> 
> **Overview**
> **CI now skips doc-only changes.** The main `ci.yml` workflow ignores pushes/PRs that only touch markdown, `docs/`, and repo meta files (templates/licenses/policies), and docs were updated to reflect this.
> 
> **Workflow setup is centralized.** `coverage.yml`, `e2e-web.yml`, and `mutation.yml` replace inline pnpm/Node/install steps with the shared `./.github/actions/setup-monorepo` action (and adjust path filters to rerun when that action changes).
> 
> **Release concurrency behavior changed.** `release.yml` now cancels in-progress runs for the same ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6690cd89fab930e46d34dd062dd2ea17bf7865a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->