### PR TITLE
chore: skip-ci label, Dependabot auto-merge, workers-only Playwright skip

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -123,7 +123,10 @@ Closes #
 - [ ] ✅ No merge conflicts
 - [ ] ✅ Ready for review
 
-<!-- Optional: add label `deploy-preview` to trigger Cloudflare preview deploy -->
+<!-- Optional labels:
+  - `deploy-preview` — trigger Cloudflare preview deploy
+  - `skip-ci` — skip CI / PR checks (trivial or docs-only when ci.yml already skipped); remove before merge if checks are required
+-->
 
 ## Additional Notes
 

--- a/.github/actions/pr-skip-ci/action.yml
+++ b/.github/actions/pr-skip-ci/action.yml
@@ -1,0 +1,26 @@
+name: PR skip-ci gate
+description: Detects the skip-ci label on pull requests (no-op on push/workflow_dispatch).
+
+inputs:
+  pr_labels:
+    description: Comma-separated PR label names (pass join(github.event.pull_request.labels.*.name, ','))
+    required: false
+    default: ''
+
+outputs:
+  skip_ci:
+    description: 'true when the PR has the skip-ci label'
+    value: ${{ steps.eval.outputs.skip_ci }}
+
+runs:
+  using: composite
+  steps:
+    - id: eval
+      shell: bash
+      run: |
+        skip=false
+        labels="${{ inputs.pr_labels }}"
+        if [[ -n "$labels" ]] && [[ ",${labels}," == *",skip-ci,"* ]]; then
+          skip=true
+        fi
+        echo "skip_ci=$skip" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,82 @@
+# GitHub Actions workflows
+
+Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [setup-monorepo](../actions/setup-monorepo) (pnpm 10, Node 22, frozen lockfile).
+
+## PR / push to `main` or `dev`
+
+| Workflow | When it runs | What it does |
+|----------|----------------|--------------|
+| [ci.yml](./ci.yml) | Code changes (not doc-only `paths-ignore`) | Duplicates (push only), smoke, typecheck, lint, format, audit, unit tests; Playwright smoke only if web paths changed |
+| [pull-request.yml](./pull-request.yml) | Every PR | Duplicate check, dependency review, TruffleHog secret scan |
+| [e2e-web.yml](./e2e-web.yml) | PRs touching `apps/web`, `packages/ui`, `packages/analysis`, lockfile, or this workflow | Playwright smoke-matrix (chromium + firefox + webkit + mobile-safari) |
+| [dependabot-automerge.yml](./dependabot-automerge.yml) | Dependabot PRs | Auto-approve + squash auto-merge for **patch** and **minor** (majors need manual review) |
+
+**Doc-only PRs** (markdown, `docs/`, templates, legal files): `ci.yml` is skipped via `paths-ignore`; `pull-request.yml` still runs.
+
+## `main` push only
+
+| Workflow | Purpose |
+|----------|---------|
+| [ci-cd.yml](./ci-cd.yml) | Quality, tests, build artifacts, CodeQL, audit |
+| [release.yml](./release.yml) | Changesets version PR / publish |
+
+## Scheduled / manual
+
+| Workflow | Schedule | Purpose |
+|----------|----------|---------|
+| [e2e-web.yml](./e2e-web.yml) | Mon 12:00 UTC | Weekly web smoke |
+| [coverage.yml](./coverage.yml) | Mon 06:00 UTC | Analysis + web coverage → Codecov |
+| [mutation.yml](./mutation.yml) | 1st of month 08:00 UTC | Analysis mutation tests |
+| [monitor-workers-health.yml](./monitor-workers-health.yml) | Daily | Workers health |
+| [monitor-r2-quotas.yml](./monitor-r2-quotas.yml) | Daily | R2 quota checks |
+
+## Deploy
+
+| Workflow | Trigger |
+|----------|---------|
+| [deploy-preview.yml](./deploy-preview.yml) | PR label `deploy-preview` or manual |
+| [deploy-production.yml](./deploy-production.yml) | Manual from `main` (confirmation input) |
+
+## Labels
+
+Create once (repo admin):
+
+```bash
+gh label create skip-ci --description "Skip CI workflows (trivial/docs-only PRs)" --color "fef2c0" 2>/dev/null || true
+gh label create deploy-preview --description "Deploy Cloudflare preview for this PR" --color "0e8a16" 2>/dev/null || true
+```
+
+| Label | Effect |
+|-------|--------|
+| `skip-ci` | `ci.yml`, `pull-request.yml`, and `e2e-web` jobs exit successfully without running checks (re-run after removing the label) |
+| `deploy-preview` | Triggers preview deploy workflow |
+
+## Path behavior
+
+### Web vs workers-only
+
+`ci.yml` skips **Playwright** when the diff has no web-related paths (`apps/web`, `packages/ui`, `packages/analysis`, root lockfile/workspace manifests). Workers-only changes still run API smoke, typecheck, lint, format, audit, and unit tests.
+
+`e2e-web.yml` only triggers on web-related paths (see workflow `paths` filter).
+
+### Doc-only
+
+Both `push` and `pull_request` on `ci.yml` use `paths-ignore` for `**.md`, `docs/**`, issue/PR templates, and legal files.
+
+## Dependabot auto-merge
+
+Requires in **Settings → General**:
+
+- **Allow auto-merge** enabled
+- Branch protection with required checks (auto-merge waits for green CI)
+
+Patch and minor Dependabot PRs are approved and queued for squash merge when checks pass. **Major** bumps require manual review.
+
+## Local equivalents
+
+```bash
+pnpm run test:ci    # CI without Playwright
+pnpm run verify     # Pre-push hook (typecheck, lint, format, unit tests)
+```
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,44 +33,104 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  gate:
+    name: CI gate
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    outputs:
+      skip_ci: ${{ steps.skip.outputs.skip_ci }}
+      run_e2e: ${{ steps.e2e.outputs.run_e2e }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Detect skip-ci label
+        id: skip
+        uses: ./.github/actions/pr-skip-ci
+        with:
+          pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+      - name: Detect web-related changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/ui/**'
+              - 'packages/analysis/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+
+      - name: Decide Playwright smoke
+        id: e2e
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.filter.outputs.web }}" == "true" ]]; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-test:
+    name: Build and test
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: CI skipped (skip-ci label)
+        if: needs.gate.outputs.skip_ci == 'true'
+        run: |
+          echo "CI skipped via skip-ci label. Remove the label or push new commits to run checks."
+
+      - name: Checkout
+        if: needs.gate.outputs.skip_ci != 'true'
+        uses: actions/checkout@v6
+
       - name: Setup monorepo
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
-        if: github.event_name != 'pull_request'
+        if: needs.gate.outputs.skip_ci != 'true' && github.event_name != 'pull_request'
         run: pnpm run check:duplicates
 
       - name: Run API smoke tests
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm test:smoke
 
       - name: Typecheck
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm run typecheck
 
       - name: Lint
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm lint
 
       - name: Format check
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm run format:check
 
       - name: Security audit
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm audit --audit-level moderate
 
       - name: Run unit tests
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm test
 
       - name: Install Playwright browsers
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e == 'true'
         working-directory: apps/web
         env:
           DEBIAN_FRONTEND: noninteractive
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e == 'true'
         working-directory: apps/web
         run: pnpm test:e2e:smoke
+
+      - name: Playwright skipped (workers-only / no web paths)
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e != 'true'
+        run: echo "Skipping Playwright — no web-related paths changed (see .github/workflows/README.md)."

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Approves and enables squash auto-merge for Dependabot patch/minor PRs once CI is green.
+# Requires: repo Settings → General → Allow auto-merge, and branch protection with required checks.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    name: Auto-merge Dependabot (patch/minor)
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+
+      - name: Major updates need manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: echo "Skipping auto-merge for major version bump — review manually."

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,7 +4,7 @@ name: Dependabot auto-merge
 # Requires: repo Settings → General → Allow auto-merge, and branch protection with required checks.
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -54,8 +54,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_ci: ${{ steps.skip.outputs.skip_ci }}
+    steps:
+      - name: Detect skip-ci label
+        id: skip
+        uses: ./.github/actions/pr-skip-ci
+        with:
+          pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
   smoke:
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke')
+    needs: [gate]
+    if: |
+      always() &&
+      (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -93,7 +108,11 @@ jobs:
           retention-days: 7
 
   smoke-matrix:
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke-matrix')
+    needs: [gate]
+    if: |
+      always() &&
+      (github.event_name != 'pull_request' || (needs.gate.result == 'success' && needs.gate.outputs.skip_ci != 'true')) &&
+      (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke-matrix'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -60,6 +60,9 @@ jobs:
     outputs:
       skip_ci: ${{ steps.skip.outputs.skip_ci }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Detect skip-ci label
         id: skip
         uses: ./.github/actions/pr-skip-ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,9 @@ jobs:
     outputs:
       skip_ci: ${{ steps.skip.outputs.skip_ci }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Detect skip-ci label
         id: skip
         uses: ./.github/actions/pr-skip-ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,28 +14,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gate:
+    name: PR gate
+    runs-on: ubuntu-latest
+    outputs:
+      skip_ci: ${{ steps.skip.outputs.skip_ci }}
+    steps:
+      - name: Detect skip-ci label
+        id: skip
+        uses: ./.github/actions/pr-skip-ci
+        with:
+          pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
   duplicate-check:
     name: Duplicate file check
+    needs: gate
     runs-on: ubuntu-latest
     steps:
+      - name: Skipped (skip-ci label)
+        if: needs.gate.outputs.skip_ci == 'true'
+        run: echo "Duplicate check skipped via skip-ci label."
+
       - name: Checkout
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: actions/checkout@v6
 
       - name: Setup monorepo
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
+        if: needs.gate.outputs.skip_ci != 'true'
         run: pnpm run check:duplicates
 
   dependency-review:
     name: Dependency review
+    needs: gate
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Skipped (skip-ci label)
+        if: needs.gate.outputs.skip_ci == 'true'
+        run: echo "Dependency review skipped via skip-ci label."
+
       - name: Checkout
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: actions/checkout@v6
 
       - name: Dependency review
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
@@ -43,14 +70,21 @@ jobs:
 
   secret-scan:
     name: Secret scan
+    needs: gate
     runs-on: ubuntu-latest
     steps:
+      - name: Skipped (skip-ci label)
+        if: needs.gate.outputs.skip_ci == 'true'
+        run: echo "Secret scan skipped via skip-ci label."
+
       - name: Checkout
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: TruffleHog OSS
+        if: needs.gate.outputs.skip_ci != 'true'
         uses: trufflesecurity/trufflehog@v3.95.3
         with:
           extra_args: --only-verified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,12 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 ## CI (do not duplicate locally)
 
 - Workflows use `.github/actions/setup-monorepo` for pnpm + Node 22 + install
-- **PR / `dev` push:** `ci.yml`, `pull-request.yml` (duplicate check), `e2e-web` (web paths)
+- **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web` (web paths only)
 - **Doc-only PRs:** skip `ci.yml`; `pull-request.yml` still runs
+- **Workers-only PRs:** full `ci.yml` minus Playwright; no `e2e-web`
+- **Labels:** `skip-ci` (skip all PR checks), `deploy-preview` (preview deploy)
+- **Dependabot:** patch/minor auto-merge via `dependabot-automerge.yml` (majors manual)
+- **Workflow map:** [.github/workflows/README.md](.github/workflows/README.md)
 - **`main` push only:** `ci-cd.yml` (artifacts, CodeQL)
 - **Never commit:** Finder duplicates (`file 2`), flat Playwright specs, or `tests/utils/nav.ts` (use `tests/_shared/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,21 @@ Report vulnerabilities privately — see [SECURITY.md](./SECURITY.md). Do not op
 - Run full local gate: `pnpm run verify`
 - Preview deploy: add the `deploy-preview` label on your PR (requires repo secrets) or run the workflow manually
 
+## CI and PR labels
+
+Workflow reference: [.github/workflows/README.md](.github/workflows/README.md).
+
+| Label | When to use |
+|-------|-------------|
+| `skip-ci` | Trivial PRs where you intentionally skip checks (jobs still report success). Remove before merge if branch protection requires green CI. |
+| `deploy-preview` | Deploy a Cloudflare preview for this PR |
+
+- **Doc-only** changes (`*.md`, `docs/`, templates): `ci.yml` does not run; `pull-request.yml` still runs.
+- **Workers-only** changes: `ci.yml` runs without Playwright; `e2e-web` does not run.
+- **Dependabot** patch/minor PRs may auto-merge when CI is green (see workflow README).
+
+Create labels once: `gh label create skip-ci --description "Skip CI workflows" --color "fef2c0"`
+
 ## Pull Request Process
 
 1. Ensure your PR includes:
@@ -204,7 +219,7 @@ Report vulnerabilities privately — see [SECURITY.md](./SECURITY.md). Do not op
    - Updated documentation if needed
 
 2. PRs require:
-   - Passing CI checks (doc-only PRs that change only `*.md` / `docs/` skip the main `ci.yml` job)
+   - Passing CI checks (doc-only PRs skip `ci.yml`; workers-only PRs skip Playwright in `ci.yml`)
    - At least one review
    - No merge conflicts
 


### PR DESCRIPTION
## Summary
- **`skip-ci` label** — reusable `pr-skip-ci` action; CI/PR/e2e jobs pass without running (branch-protection safe)
- **Workers-only path tuning** — `ci.yml` skips Playwright when diff has no web-related paths
- **Dependabot auto-merge** — approves and enables squash auto-merge for patch/minor Dependabot PRs
- **`.github/workflows/README.md`** — workflow map, labels, path behavior, local commands
- Created `skip-ci` label on the repo

## Test plan
- [x] Commit passed lefthook
- [ ] CI green on PR
- [ ] Verify workers-only PR skips Playwright (manual follow-up)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI execution/branch-protection behavior and adds automated approval/merge for Dependabot PRs, which could reduce test coverage if misused or misconfigured.
> 
> **Overview**
> Adds a reusable `.github/actions/pr-skip-ci` composite action and wires it into `ci.yml`, `pull-request.yml`, and `e2e-web.yml` so PRs labeled `skip-ci` short-circuit jobs while still reporting success.
> 
> Updates `ci.yml` to conditionally run Playwright smoke only when web-related paths change (or on `workflow_dispatch`), and adds a new `dependabot-automerge.yml` workflow to auto-approve + enable squash auto-merge for Dependabot *patch/minor* updates.
> 
> Documents the new CI/label behavior in `.github/workflows/README.md`, and updates `CONTRIBUTING.md`, `AGENTS.md`, and the PR template to reference `skip-ci`/`deploy-preview` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab5b72e1cb7f21d64409074c0abbc0ce92a666b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skip-ci` label to optionally skip CI pipeline checks on pull requests.
  * Enabled automatic approval and squash-merge for Dependabot patch and minor version updates.
  * Implemented smart CI job execution that conditionally runs based on which files changed.

* **Documentation**
  * Added detailed GitHub Actions workflow documentation explaining CI/CD processes.
  * Updated contributor guidelines with CI label usage and workflow behavior details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->