### PR TITLE
chore: label sync, PR labeler, Dependabot workspaces, test:ci:full

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,51 @@ updates:
       - 'backend'
 
   - package-ecosystem: 'npm'
+    directory: '/workers/web'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    assignees:
+      - 'blakeox'
+    labels:
+      - 'dependencies'
+      - 'automated'
+      - 'backend'
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/ui'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    assignees:
+      - 'blakeox'
+    labels:
+      - 'dependencies'
+      - 'automated'
+      - 'frontend'
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/tools'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    assignees:
+      - 'blakeox'
+    labels:
+      - 'dependencies'
+      - 'automated'
+      - 'tools'
+
+  - package-ecosystem: 'npm'
     directory: '/packages/analysis'
     schedule:
       interval: 'weekly'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/web/**'
+      - any-glob-to-any-file: 'packages/ui/**'
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file: 'workers/**'
+
+analysis:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/analysis/**'
+
+tools:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tools/**'
+
+github-actions:
+  - changed-files:
+      - any-glob-to-any-file: '.github/workflows/**'
+      - any-glob-to-any-file: '.github/actions/**'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,24 @@
+# Canonical repo labels — synced by .github/workflows/sync-labels.yml
+- name: skip-ci
+  color: fef2c0
+  description: Skip CI workflows (trivial or docs-only PRs)
+
+- name: deploy-preview
+  color: 0e8a16
+  description: Deploy Cloudflare preview for this PR
+
+- name: frontend
+  color: 168700
+  description: Changes to apps/web or packages/ui
+
+- name: backend
+  color: 0366d6
+  description: Changes to workers/api or workers/web
+
+- name: analysis
+  color: 7057ff
+  description: Changes to packages/analysis engines
+
+- name: tools
+  color: c5def5
+  description: Changes to packages/tools (MCP handlers)

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,3 +22,7 @@
 - name: tools
   color: c5def5
   description: Changes to packages/tools (MCP handlers)
+
+- name: github-actions
+  color: e6e6e6
+  description: Changes to GitHub Actions workflows or actions

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,8 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 | [pull-request.yml](./pull-request.yml) | Every PR | Duplicate check, dependency review, TruffleHog secret scan |
 | [e2e-web.yml](./e2e-web.yml) | PRs touching `apps/web`, `packages/ui`, `packages/analysis`, lockfile, or this workflow | Playwright smoke-matrix (chromium + firefox + webkit + mobile-safari) |
 | [dependabot-automerge.yml](./dependabot-automerge.yml) | Dependabot PRs | Auto-approve + squash auto-merge for **patch** and **minor** (majors need manual review) |
+| [pr-labeler.yml](./pr-labeler.yml) | Every PR | Path-based labels (`frontend`, `backend`, `analysis`, `tools`, `github-actions`) |
+| [sync-labels.yml](./sync-labels.yml) | Push to `main` when [labels.yml](../labels.yml) changes | Keeps GitHub labels in sync |
 
 **Doc-only PRs** (markdown, `docs/`, templates, legal files): `ci.yml` is skipped via `paths-ignore`; `pull-request.yml` still runs.
 
@@ -39,17 +41,13 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 
 ## Labels
 
-Create once (repo admin):
-
-```bash
-gh label create skip-ci --description "Skip CI workflows (trivial/docs-only PRs)" --color "fef2c0" 2>/dev/null || true
-gh label create deploy-preview --description "Deploy Cloudflare preview for this PR" --color "0e8a16" 2>/dev/null || true
-```
+Canonical definitions live in [.github/labels.yml](../labels.yml). After merging label changes to `main`, run **Sync GitHub labels** (`sync-labels.yml`) or push to `main` to apply.
 
 | Label | Effect |
 |-------|--------|
 | `skip-ci` | `ci.yml`, `pull-request.yml`, and `e2e-web` jobs exit successfully without running checks (re-run after removing the label) |
 | `deploy-preview` | Triggers preview deploy workflow |
+| `frontend` / `backend` / `analysis` / `tools` | Applied automatically by [pr-labeler.yml](./pr-labeler.yml) from changed paths |
 
 ## Path behavior
 
@@ -72,11 +70,21 @@ Requires in **Settings → General**:
 
 Patch and minor Dependabot PRs are approved and queued for squash merge when checks pass. **Major** bumps require manual review.
 
+Dependabot watches: `/`, `/apps/web`, `/workers/api`, `/workers/web`, `/packages/analysis`, `/packages/ui`, `/packages/tools`, and GitHub Actions.
+
+## Repository settings checklist (maintainers)
+
+1. **General → Allow auto-merge** — required for Dependabot auto-merge
+2. **Branches → `main` / `dev` protection** — require `build-and-test` (or job name from `ci.yml`), PR reviews, up-to-date branch
+3. **Secrets** — Cloudflare tokens for deploy workflows; optional `CODECOV_TOKEN`, Slack webhooks for monitors
+4. **Environments** — `preview` / `production` with protection rules if using deploy workflows
+
 ## Local equivalents
 
 ```bash
-pnpm run test:ci    # CI without Playwright
-pnpm run verify     # Pre-push hook (typecheck, lint, format, unit tests)
+pnpm run test:ci       # CI without Playwright
+pnpm run test:ci:full  # test:ci + Playwright smoke (matches CI when web paths change)
+pnpm run verify        # Pre-push hook (typecheck, lint, format, unit tests)
 ```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,22 @@
+name: PR labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Sync labels from .github/labels.yml
-        uses: micnncim/action-label-sync@v2
+        uses: micnncim/action-label-syncer@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prune: false

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,25 @@
+name: Sync GitHub labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Sync labels from .github/labels.yml
+        uses: micnncim/action-label-sync@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prune: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Guidance for AI coding assistants working in this repository.
 ```bash
 pnpm run setup:local   # clean install + Playwright chromium (first time / broken node_modules)
 pnpm run test:ci       # CI job without Playwright (~5 min): duplicates, smoke, typecheck, lint, format, audit, tests
+pnpm run test:ci:full  # test:ci + Playwright smoke (when web paths would run e2e in CI)
 pnpm run verify        # Full gate: duplicates, typecheck, lint, format, unit tests (hooks / pre-push)
 pnpm run build:libs    # build @financial-analysis/analysis + ui (runs before typecheck via pretypecheck)
 pnpm run dev           # Astro build + web worker (8788) + API (8787)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ Run tests, typecheck, and lint across the monorepo:
 ```bash
 pnpm run build:libs  # Build analysis + ui (required before typecheck on fresh clone)
 pnpm run test:ci     # CI without Playwright: duplicates, smoke, typecheck, lint, format, audit, tests
+pnpm run test:ci:full  # test:ci + Playwright smoke (full CI for web changes)
 pnpm run verify      # duplicates + build:libs + typecheck + lint + format + test (pre-push hook)
 pnpm test            # Run all workspace unit tests
 pnpm typecheck       # Typecheck all packages (runs build:libs first via pretypecheck)
@@ -208,7 +209,7 @@ Workflow reference: [.github/workflows/README.md](.github/workflows/README.md).
 - **Workers-only** changes: `ci.yml` runs without Playwright; `e2e-web` does not run.
 - **Dependabot** patch/minor PRs may auto-merge when CI is green (see workflow README).
 
-Create labels once: `gh label create skip-ci --description "Skip CI workflows" --color "fef2c0"`
+Labels are defined in [.github/labels.yml](.github/labels.yml) and synced via the **Sync GitHub labels** workflow on `main`.
 
 ## Pull Request Process
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pretypecheck": "pnpm run build:libs",
     "typecheck": "pnpm --recursive run typecheck",
     "test:ci": "pnpm run check:duplicates && pnpm test:smoke && pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm audit --audit-level moderate && pnpm test",
+    "test:ci:full": "pnpm run test:ci && pnpm --filter @financial-analysis/web exec playwright install chromium && pnpm --filter @financial-analysis/web run test:e2e:smoke",
     "verify": "pnpm run check:duplicates && pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test",
     "check:duplicates": "node scripts/check-repo-duplicates.mjs",
     "clean:finder-duplicates": "node scripts/clean-finder-duplicates.mjs",


### PR DESCRIPTION
## Summary
- **`.github/labels.yml`** + `sync-labels.yml` — canonical labels (`skip-ci`, `deploy-preview`, path labels)
- **`pr-labeler.yml`** — auto-label PRs by changed paths (`frontend`, `backend`, `analysis`, `tools`, `github-actions`)
- **Dependabot** — add `workers/web`, `packages/ui`, `packages/tools`
- **`pnpm run test:ci:full`** — local mirror of CI including Playwright smoke
- Maintainer checklist in workflows README

## Test plan
- [x] Commit passed lefthook
- [ ] CI green
- [ ] PR labeler applies labels on this PR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily GitHub automation changes; risk is moderate because new workflows can alter PR labeling/permissions and Dependabot update scope, potentially affecting repo hygiene and CI behavior but not runtime code.
> 
> **Overview**
> Adds GitHub repo automation for label management: introduces canonical labels in `.github/labels.yml`, a `sync-labels.yml` workflow to keep GitHub labels in sync on `main`, and a `pr-labeler.yml` workflow using `actions/labeler` to apply path-based labels (`frontend`, `backend`, `analysis`, `tools`, `github-actions`) from `.github/labeler.yml`.
> 
> Expands Dependabot coverage to additional npm workspaces (`workers/web`, `packages/ui`, `packages/tools`) and updates docs to reflect the new labeling/sync flows and a maintainer settings checklist.
> 
> Adds a new root script `test:ci:full` to run the existing CI gate plus Playwright chromium install and web smoke e2e, and documents it in `AGENTS.md`/`CONTRIBUTING.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2bad99fa64998d2721ee3774a8d342494c0758. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->