### PR TITLE
chore(ci): retry Dependabot auto-merge after CI completes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,7 +69,7 @@ Requires in **Settings → General**:
 - **Allow auto-merge** enabled
 - Branch protection with required checks (auto-merge waits for green CI)
 
-Patch and minor Dependabot PRs are queued for squash auto-merge when checks pass (no bot approval — branch protection has 0 required reviews). **Major** bumps require manual review.
+Patch and minor Dependabot PRs are queued for squash auto-merge when **CI** passes (`dependabot-automerge.yml` runs on PR open and again after the CI workflow completes). No bot approval — branch protection has 0 required reviews. **Major** bumps require manual review.
 
 Dependabot uses a **single root** `npm` entry so `pnpm-lock.yaml` stays in sync; path labels come from `pr-labeler.yml`.
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,12 +1,15 @@
 name: Dependabot auto-merge
 
-# Enables squash auto-merge for Dependabot patch/minor PRs once required checks pass.
-# Does not submit PR reviews (blocked unless "Allow GitHub Actions to approve pull requests" is on).
+# Queues squash auto-merge for Dependabot patch/minor PRs when CI succeeds.
+# Retries on workflow_run after CI (initial open may run before checks are required).
 # Requires: Settings → General → Allow auto-merge.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 permissions:
   contents: write
@@ -16,23 +19,51 @@ jobs:
   dependabot-automerge:
     name: Auto-merge Dependabot (patch/minor)
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request')
     steps:
+      - name: Resolve PR number
+        id: pr
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip non-Dependabot PRs
+        id: author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          login=$(gh pr view "${{ steps.pr.outputs.number }}" --json author --jq .author.login)
+          if [[ "$login" != "dependabot[bot]" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Not a Dependabot PR — skipping."
+          fi
+
       - name: Dependabot metadata
+        if: steps.author.outputs.skip != 'true'
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
 
       - name: Enable auto-merge (patch/minor)
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.author.outputs.skip != 'true' && (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "${{ steps.pr.outputs.number }}"
 
       - name: Major updates need manual review
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: steps.author.outputs.skip != 'true' && steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: echo "Skipping auto-merge for major version bump — review manually."

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -46,24 +46,58 @@ jobs:
             echo "Not a Dependabot PR — skipping."
           fi
 
-      - name: Dependabot metadata
-        if: steps.author.outputs.skip != 'true'
+      - name: Dependabot metadata (pull_request_target only)
+        if: steps.author.outputs.skip != 'true' && github.event_name == 'pull_request_target'
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ steps.pr.outputs.number }}
+
+      - name: Detect update type from PR title (workflow_run)
+        if: steps.author.outputs.skip != 'true' && github.event_name == 'workflow_run'
+        id: title-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title=$(gh pr view "${{ steps.pr.outputs.number }}" --json title --jq .title)
+          # Parse "Bump X from A.B.C to D.E.F" format used by Dependabot
+          if [[ "$title" =~ from\ ([0-9]+)\.([0-9]+)\.[0-9]+\ to\ ([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
+            old_major="${BASH_REMATCH[1]}" old_minor="${BASH_REMATCH[2]}"
+            new_major="${BASH_REMATCH[3]}" new_minor="${BASH_REMATCH[4]}"
+            if (( new_major > old_major )); then
+              echo "update-type=major" >> "$GITHUB_OUTPUT"
+            elif (( new_minor > old_minor )); then
+              echo "update-type=minor" >> "$GITHUB_OUTPUT"
+            else
+              echo "update-type=patch" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::Could not parse version from title: $title"
+            echo "update-type=unknown" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Enable auto-merge (patch/minor)
         if: |
           steps.author.outputs.skip != 'true' && (
-            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            (github.event_name == 'pull_request_target' && (
+              steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+              steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            )) ||
+            (github.event_name == 'workflow_run' && (
+              steps.title-check.outputs.update-type == 'patch' ||
+              steps.title-check.outputs.update-type == 'minor'
+            ))
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.number }}"
 
       - name: Major updates need manual review
-        if: steps.author.outputs.skip != 'true' && steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: |
+          steps.author.outputs.skip != 'true' && (
+            (github.event_name == 'pull_request_target' &&
+              steps.metadata.outputs.update-type == 'version-update:semver-major') ||
+            (github.event_name == 'workflow_run' &&
+              steps.title-check.outputs.update-type == 'major')
+          )
         run: echo "Skipping auto-merge for major version bump — review manually."

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:ci:full": "pnpm run test:ci && pnpm --filter @financial-analysis/web exec playwright install chromium && pnpm --filter @financial-analysis/web run test:e2e:smoke",
     "verify": "pnpm run check:duplicates && pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test",
     "check:duplicates": "node scripts/check-repo-duplicates.mjs",
+    "check:duplicates:files": "node scripts/check-repo-duplicates.mjs --files-only",
     "clean:finder-duplicates": "node scripts/clean-finder-duplicates.mjs",
     "reinstall": "rm -rf node_modules apps/*/node_modules packages/*/node_modules workers/*/node_modules && pnpm install",
     "setup:local": "pnpm run reinstall && pnpm --filter @financial-analysis/web exec playwright install chromium",


### PR DESCRIPTION
## Summary
- Re-run Dependabot auto-merge when **CI** workflow completes successfully (fixes PRs that opened before checks were green)
- Add `pnpm run check:duplicates:files` for local/CI file-scan without `test:layout`

Also closed superseded Dependabot PRs #253, #254, #256 and merged #255 (github-actions).

## Test plan
- [ ] CI green
- [ ] Next Dependabot PR auto-merges after CI

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Dependabot auto-merge workflow trigger/logic and could accidentally merge the wrong PR or fail to merge if the PR resolution/author check is wrong. Scoped to Dependabot PRs and only runs after successful CI, limiting blast radius.
> 
> **Overview**
> Ensures Dependabot patch/minor PRs get queued for squash auto-merge *after CI succeeds* by rerunning `dependabot-automerge.yml` on `workflow_run` completion in addition to PR open/sync.
> 
> The workflow now resolves the PR number for both event types, explicitly skips non-Dependabot PRs, and passes the PR number into `dependabot/fetch-metadata` before invoking `gh pr merge --auto --squash`. Adds a new `pnpm run check:duplicates:files` script to run the duplicate-file scan without the web `test:layout` step, and updates workflow docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26127da9e0faa3dba93b444e6505518e5a23c40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->