### PR TITLE
fix(ci): changesets with js-yaml 4 and skip empty release runs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,6 +75,8 @@ Dependabot uses a **single root** `npm` entry so `pnpm-lock.yaml` stays in sync;
 
 Optional: enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** if you later require PR approvals for auto-merge.
 
+**Dependabot PRs and CI:** Enable **Settings → Actions → General → Run workflows from Dependabot pull requests** so `ci.yml` runs on dependency PRs (auto-merge waits for those checks). Without this, only `pull_request_target` workflows (e.g. auto-merge) run until a maintainer approves workflow execution.
+
 ## Repository settings checklist (maintainers)
 
 1. **General → Allow auto-merge** — required for Dependabot auto-merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,28 +25,10 @@ jobs:
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
 
-      - name: Check for pending changesets
-        id: pending
-        shell: bash
-        run: |
-          found=false
-          for f in .changeset/*.md; do
-            [[ -f "$f" ]] || continue
-            [[ "$(basename "$f")" == "README.md" ]] && continue
-            found=true
-            break
-          done
-          echo "found=$found" >> "$GITHUB_OUTPUT"
-
-      - name: Create Release PR with Changesets
-        if: steps.pending.outputs.found == 'true'
+      - name: Create Release PR or Publish with Changesets
         uses: changesets/action@v1
         with:
           version: pnpm -w changeset version
           publish: pnpm -w changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: No pending changesets
-        if: steps.pending.outputs.found != 'true'
-        run: echo "No changesets to version or publish — skipping release job."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,28 @@ jobs:
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
 
+      - name: Check for pending changesets
+        id: pending
+        shell: bash
+        run: |
+          found=false
+          for f in .changeset/*.md; do
+            [[ -f "$f" ]] || continue
+            [[ "$(basename "$f")" == "README.md" ]] && continue
+            found=true
+            break
+          done
+          echo "found=$found" >> "$GITHUB_OUTPUT"
+
       - name: Create Release PR with Changesets
+        if: steps.pending.outputs.found == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm -w changeset version
           publish: pnpm -w changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: No pending changesets
+        if: steps.pending.outputs.found != 'true'
+        run: echo "No changesets to version or publish — skipping release job."

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     ],
     "overrides": {
       "js-yaml": ">=4.1.1",
+      "read-yaml-file@1.1.0>js-yaml": "3.14.1",
       "astro": ">=6.1.10",
       "vite": ">=8.0.13",
       "devalue": ">=5.8.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     ],
     "overrides": {
       "js-yaml": ">=4.1.1",
-      "read-yaml-file@1.1.0>js-yaml": "3.14.1",
+      "read-yaml-file@1.1.0>js-yaml": "3.14.2",
       "astro": ">=6.1.10",
       "vite": ">=8.0.13",
       "devalue": ">=5.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   js-yaml: '>=4.1.1'
-  read-yaml-file@1.1.0>js-yaml: 3.14.1
+  read-yaml-file@1.1.0>js-yaml: 3.14.2
   astro: '>=6.1.10'
   vite: '>=8.0.13'
   devalue: '>=5.8.1'
@@ -4063,8 +4063,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -8045,7 +8045,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -9762,7 +9762,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -10717,7 +10717,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   js-yaml: '>=4.1.1'
+  read-yaml-file@1.1.0>js-yaml: 3.14.1
   astro: '>=6.1.10'
   vite: '>=8.0.13'
   devalue: '>=5.8.1'
@@ -2757,6 +2758,9 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4059,6 +4063,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -5189,6 +5197,9 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -8267,6 +8278,10 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -9747,6 +9762,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -10697,7 +10717,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.1.1
+      js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -11097,6 +11117,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 


### PR DESCRIPTION
## Summary
- Pin `js-yaml@3` for `read-yaml-file` so `@changesets/cli` works alongside the repo's `js-yaml@4` security override
- Skip `release.yml` when there are no pending changesets (avoids failed `changeset publish` on every main push)
- Document **Run workflows from Dependabot pull requests** in Actions settings

## Test plan
- [x] `pnpm -w changeset status` succeeds locally
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation behavior and dependency resolution via pnpm overrides, which could affect publishing and tooling across the repo.
> 
> **Overview**
> Fixes Changesets tooling under the repo’s `js-yaml@4` security override by adding a targeted pnpm override so `read-yaml-file@1.1.0` resolves `js-yaml@3.14.1` (and updates `pnpm-lock.yaml` accordingly).
> 
> Updates `release.yml` to **skip running `changesets/action`** when there are no pending changeset files, avoiding no-op publish/version failures on `main` pushes, and documents the GitHub setting needed to allow `ci.yml` to run on Dependabot PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf2257a2718e6dd7fcb89129bfac97ebb2ef144. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->