### PR TITLE
fix(ci): guard release and Dependabot auto-merge on empty PR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 | Workflow | Purpose |
 |----------|---------|
 | [ci-cd.yml](./ci-cd.yml) | Quality, tests, build artifacts, CodeQL, audit |
-| [release.yml](./release.yml) | Changesets version PR / publish |
+| [release.yml](./release.yml) | Changesets version PR when `.changeset/*.md` exist (no npm publish) |
 
 ## Scheduled / manual
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,7 +23,8 @@ jobs:
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
       (github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'pull_request')
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.pull_requests[0] != null)
     steps:
       - name: Resolve PR number
         id: pr
@@ -37,8 +38,10 @@ jobs:
 
       - name: Skip non-Dependabot PRs
         id: author
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           login=$(gh pr view "${{ steps.pr.outputs.number }}" --json author --jq .author.login)
           if [[ "$login" != "dependabot[bot]" ]]; then
@@ -52,15 +55,16 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
 
       - name: Detect update type from PR title (workflow_run)
         if: steps.author.outputs.skip != 'true' && github.event_name == 'workflow_run'
         id: title-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           title=$(gh pr view "${{ steps.pr.outputs.number }}" --json title --jq .title)
-          # Parse "Bump X from A.B.C to D.E.F" format used by Dependabot
           if [[ "$title" =~ from\ ([0-9]+)\.([0-9]+)\.[0-9]+\ to\ ([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
             old_major="${BASH_REMATCH[1]}" old_minor="${BASH_REMATCH[2]}"
             new_major="${BASH_REMATCH[3]}" new_minor="${BASH_REMATCH[4]}"
@@ -90,6 +94,7 @@ jobs:
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.number }}"
 
       - name: Major updates need manual review

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,29 @@ jobs:
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
 
-      - name: Create Release PR or Publish with Changesets
+      - name: Check for pending changesets
+        id: pending
+        shell: bash
+        run: |
+          found=false
+          for f in .changeset/*.md; do
+            [[ -f "$f" ]] || continue
+            [[ "$(basename "$f")" == "README.md" ]] && continue
+            found=true
+            break
+          done
+          echo "found=$found" >> "$GITHUB_OUTPUT"
+
+      - name: Create Release PR with Changesets
+        if: steps.pending.outputs.found == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm -w changeset version
-          publish: pnpm -w changeset publish
+          # Monorepo is not published to npm; version PR only.
+          publish: echo "Skipping npm publish — packages are consumed in-repo."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: No pending changesets
+        if: steps.pending.outputs.found != 'true'
+        run: echo "No changesets to version — skipping release job."


### PR DESCRIPTION
## Summary
- **release.yml**: skip when no pending changesets; noop npm publish (fixes ENEEDAUTH on every main push)
- **dependabot-automerge.yml**: require linked PR on `workflow_run`; set `GH_REPO` for `gh` CLI (fixes empty PR number failures)

Removed local stale `.changeset/add-api-docs-route.md` (feature already shipped).

## Test plan
- [ ] CI green
- [ ] Release workflow passes on merge to main

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI/CD automation behavior (release PR creation and Dependabot merging), which could inadvertently skip expected releases or auto-merges if the new conditions are wrong.
> 
> **Overview**
> Prevents the `release.yml` workflow from running Changesets unless real `.changeset/*.md` files are present, and replaces the publish step with a no-op to avoid npm auth failures on `main` pushes.
> 
> Hardens `dependabot-automerge.yml` by requiring a linked PR on `workflow_run`, setting `GH_REPO` for `gh` CLI calls, and skipping steps when the PR number can’t be resolved, avoiding failures on empty/unsupported events.
> 
> Updates the workflows README to reflect that `release.yml` now only opens version PRs when changesets exist and never publishes to npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c95a4d20623e795fb9c8ebbf737c9703cc12806. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow documentation to clarify that it creates version pull requests without publishing packages to npm.

* **Chores**
  * Enhanced release workflow to validate the presence of pending changes before proceeding with version pull request creation.
  * Improved Dependabot automerge workflow with more selective conditional logic and enhanced environment context for better reliability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->