### PR TITLE
fix(ci): repair coverage workflow invalid secrets in if

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,8 +35,19 @@ jobs:
       - name: Run analysis coverage
         run: pnpm --filter @financial-analysis/analysis run test:coverage:ci
 
+      - name: Detect Codecov token
+        id: codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [[ -n "$CODECOV_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage (Codecov)
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: steps.codecov.outputs.enabled == 'true'
         uses: codecov/codecov-action@v6
         with:
           files: packages/analysis/coverage/coverage-final.json
@@ -45,7 +56,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Codecov skipped (no token)
-        if: ${{ secrets.CODECOV_TOKEN == '' }}
+        if: steps.codecov.outputs.enabled != 'true'
         run: echo "CODECOV_TOKEN not configured — coverage artifacts uploaded only."
 
       - name: Upload analysis coverage artifacts
@@ -71,8 +82,19 @@ jobs:
       - name: Run web coverage
         run: pnpm --filter @financial-analysis/web run test:coverage
 
+      - name: Detect Codecov token
+        id: codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [[ -n "$CODECOV_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload web coverage (Codecov)
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: steps.codecov.outputs.enabled == 'true'
         uses: codecov/codecov-action@v6
         with:
           files: apps/web/coverage/vitest/lcov.info
@@ -81,7 +103,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Codecov skipped (no token)
-        if: ${{ secrets.CODECOV_TOKEN == '' }}
+        if: steps.codecov.outputs.enabled != 'true'
         run: echo "CODECOV_TOKEN not configured — coverage artifacts uploaded only."
 
       - name: Upload web coverage artifacts

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -51,7 +51,7 @@ jobs:
           fi
           login=$(echo "$pr_json" | jq -r .user.login)
           state=$(echo "$pr_json" | jq -r .state)
-          if [[ "$login" != "dependabot[bot]" ]] || [[ "$state" != "open" ]]; then
+          if [[ "$login" != "dependabot[bot]" ]] || [[ "${state,,}" != "open" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping (author=$login, state=$state)."
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,11 @@ Workflow reference: [.github/workflows/README.md](.github/workflows/README.md).
 
 Labels are defined in [.github/labels.yml](.github/labels.yml) and synced via the **Sync GitHub labels** workflow on `main`.
 
+**Repo settings (maintainers):**
+
+- **Actions → Run workflows from Dependabot pull requests** — so dependency PRs run full CI before auto-merge
+- **Secrets → `CODECOV_TOKEN`** (optional) — uploads coverage to Codecov from [coverage.yml](.github/workflows/coverage.yml)
+
 ## Pull Request Process
 
 1. Ensure your PR includes:


### PR DESCRIPTION
## Summary
- Fixes **Coverage** workflow failing at parse time (`secrets` cannot be used in step `if` expressions).
- Detects `CODECOV_TOKEN` via a shell step output; uploads to Codecov only when configured; always uploads artifacts.
- Normalizes Dependabot auto-merge PR `state` check (case-insensitive).
- Documents optional `CODECOV_TOKEN` and Dependabot workflow setting in CONTRIBUTING.

## Test plan
- [ ] Coverage workflow runs on this PR (path touches `coverage.yml`)
- [ ] Jobs complete without workflow file validation errors
- [ ] Codecov step skipped with informative log when no token


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes that adjust GitHub Actions step gating and a Dependabot state check; main risk is accidentally skipping Codecov uploads when a token is present due to output/condition mismatch.
> 
> **Overview**
> Fixes the `coverage.yml` workflow to avoid using `secrets` directly in step `if` conditions by adding a `Detect Codecov token` step and gating Codecov uploads/skips via step outputs (while still always uploading coverage artifacts).
> 
> Tweaks `dependabot-automerge.yml` to treat PR `state` as case-insensitive when deciding whether to skip. Updates `CONTRIBUTING.md` to document the optional `CODECOV_TOKEN` secret and a Dependabot Actions setting needed for dependency PRs to run full CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028f6c0108bd7265bc81b55650c069d31dd94236. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->