### PR TITLE
fix(ci): run CI on every PR and require Build and test

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -33,7 +33,7 @@ pnpm run sync:branch-protection
 node scripts/sync-branch-protection.mjs --dry-run
 ```
 
-Default required checks: **PR gate**, **Secret scan** (always run on PRs). **Build and test** is not required at the protection layer because `ci.yml` skips doc-only paths; still require green CI for code changes before merging.
+Default required checks: **PR gate**, **Secret scan**, **CI gate**, **Build and test** (all run on every PR; doc-only PRs skip heavy CI steps but still report success).
 
 ## 4. Auto-merge and Dependabot
 

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -13,11 +13,10 @@
   },
   "required_status_checks": {
     "strict": true,
-    "contexts": ["PR gate", "Secret scan"]
+    "contexts": ["PR gate", "Secret scan", "CI gate", "Build and test"]
   },
   "notes": [
-    "PR gate and Secret scan run on every PR via pull-request.yml (including doc-only).",
-    "Build and test (ci.yml) is intentionally not required here because ci.yml skips doc-only paths; code PRs should still pass CI before merge.",
-    "For stricter protection, add Build and test after changing ci.yml to always run a no-op job on doc-only PRs."
+    "All four checks run on every PR. Doc-only PRs skip heavy CI steps but still report Build and test success.",
+    "Push to main/dev with doc-only paths still skips ci.yml via paths-ignore on push."
   ]
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 
 | Workflow | When it runs | What it does |
 |----------|----------------|--------------|
-| [ci.yml](./ci.yml) | Code changes (not doc-only `paths-ignore`) | Duplicates (push only), smoke, typecheck, lint, format, audit, unit tests; Playwright smoke only if web paths changed |
+| [ci.yml](./ci.yml) | Every PR; push when not doc-only `paths-ignore` | Duplicates (push only), smoke, typecheck, lint, format, audit, unit tests; Playwright when web paths change; doc-only PRs skip heavy steps |
 | [pull-request.yml](./pull-request.yml) | Every PR | Duplicate check, dependency review, TruffleHog secret scan |
 | [e2e-web.yml](./e2e-web.yml) | PRs touching `apps/web`, `packages/ui`, `packages/analysis`, lockfile, or this workflow | Playwright smoke-matrix (chromium + firefox + webkit + mobile-safari) |
 | [dependabot-automerge.yml](./dependabot-automerge.yml) | Dependabot PRs | Auto-approve + squash auto-merge for **patch** and **minor** (majors need manual review) |
@@ -15,7 +15,7 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 | [stale.yml](./stale.yml) | Mon 14:00 UTC | Marks inactive issues/PRs stale (30d) and closes after 14d more |
 | [scorecard.yml](./scorecard.yml) | Mon 08:00 UTC | OpenSSF Scorecard supply-chain analysis (SARIF → Security tab) |
 
-**Doc-only PRs** (markdown, `docs/`, templates, legal files): `ci.yml` is skipped via `paths-ignore`; `pull-request.yml` runs secret scan only (no duplicate check or dependency review).
+**Doc-only PRs** (markdown, `docs/`, templates, legal files): `ci.yml` and `pull-request.yml` still run; **Build and test** and **PR gate** succeed quickly without install. Duplicate check and dependency review are skipped.
 
 ## `main` push only
 
@@ -61,7 +61,7 @@ Canonical definitions live in [.github/labels.yml](../labels.yml). After merging
 
 ### Doc-only
 
-Both `push` and `pull_request` on `ci.yml` use `paths-ignore` for `**.md`, `docs/**`, issue/PR templates, and legal files.
+`push` on `ci.yml` uses `paths-ignore` for doc-only paths. `pull_request` always triggers `ci.yml` (doc-only jobs skip heavy steps).
 
 ## Dependabot auto-merge
 
@@ -84,7 +84,7 @@ Full steps: [.github/MAINTAINER_SETUP.md](../MAINTAINER_SETUP.md).
 
 1. **General → Allow auto-merge** — required for Dependabot auto-merge
 2. **Actions → Run workflows from Dependabot pull requests** — full CI on dependency PRs
-3. **Branch protection** — `pnpm run sync:branch-protection` applies [.github/branch-protection.json](../branch-protection.json) (`PR gate`, `Secret scan`)
+3. **Branch protection** — `pnpm run sync:branch-protection` applies [.github/branch-protection.json](../branch-protection.json) (`PR gate`, `Secret scan`, `CI gate`, `Build and test`)
 4. **Secrets** — Cloudflare tokens for deploy; optional `CODECOV_TOKEN`; Slack for monitors
 5. **Environments** — `preview` / `production` with protection rules if using deploy workflows
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
       - name: Detect non-doc code changes
-        id: code
+        id: code-filter
         uses: dorny/paths-filter@v4
         with:
           filters: |
@@ -56,6 +56,16 @@ jobs:
               - '!LICENSE'
               - '!CODE_OF_CONDUCT.md'
               - '!SECURITY.md'
+
+      - name: Decide code changed
+        id: code
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.code-filter.outputs.code }}" == "true" ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Detect web-related changes
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,6 @@ on:
       - 'SECURITY.md'
   pull_request:
     branches: [main, dev]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/chatmodes/**'
-      - 'LICENSE'
-      - 'CODE_OF_CONDUCT.md'
-      - 'SECURITY.md'
   workflow_dispatch:
 
 permissions:
@@ -38,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       skip_ci: ${{ steps.skip.outputs.skip_ci }}
+      code_changed: ${{ steps.code.outputs.code }}
       run_e2e: ${{ steps.e2e.outputs.run_e2e }}
     steps:
       - name: Checkout
@@ -48,6 +40,22 @@ jobs:
         uses: ./.github/actions/pr-skip-ci
         with:
           pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+      - name: Detect non-doc code changes
+        id: code
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!.github/chatmodes/**'
+              - '!LICENSE'
+              - '!CODE_OF_CONDUCT.md'
+              - '!SECURITY.md'
 
       - name: Detect web-related changes
         id: filter
@@ -83,54 +91,58 @@ jobs:
         run: |
           echo "CI skipped via skip-ci label. Remove the label or push new commits to run checks."
 
+      - name: Doc-only change (no code paths)
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed != 'true'
+        run: echo "Doc-only PR — skipping install, typecheck, lint, audit, and tests."
+
       - name: Checkout
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         uses: actions/checkout@v6
 
       - name: Setup monorepo
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         uses: ./.github/actions/setup-monorepo
 
       - name: Check for duplicate files
-        if: needs.gate.outputs.skip_ci != 'true' && github.event_name != 'pull_request'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true' && github.event_name != 'pull_request'
         run: pnpm run check:duplicates
 
       - name: Run API smoke tests
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm test:smoke
 
       - name: Typecheck
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm run typecheck
 
       - name: Lint
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm lint
 
       - name: Format check
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm run format:check
 
       - name: Security audit
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm audit --audit-level moderate
 
       - name: Run unit tests
-        if: needs.gate.outputs.skip_ci != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
         run: pnpm test
 
       - name: Install Playwright browsers
-        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e == 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true' && needs.gate.outputs.run_e2e == 'true'
         working-directory: apps/web
         env:
           DEBIAN_FRONTEND: noninteractive
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests
-        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e == 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true' && needs.gate.outputs.run_e2e == 'true'
         working-directory: apps/web
         run: pnpm test:e2e:smoke
 
       - name: Playwright skipped (workers-only / no web paths)
-        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.run_e2e != 'true'
+        if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true' && needs.gate.outputs.run_e2e != 'true'
         run: echo "Skipping Playwright — no web-related paths changed (see .github/workflows/README.md)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 
 - Workflows use `.github/actions/setup-monorepo` for pnpm + Node 22 + install
 - **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web` (web paths only)
-- **Doc-only PRs:** skip `ci.yml`; `pull-request.yml` still runs
+- **Doc-only PRs:** `ci.yml` runs but skips install/tests; `pull-request.yml` skips duplicate/dependency review
 - **Workers-only PRs:** full `ci.yml` minus Playwright; no `e2e-web`
 - **Labels:** `skip-ci` (skip all PR checks), `deploy-preview` (preview deploy)
 - **Dependabot:** patch/minor auto-merge via `dependabot-automerge.yml` (majors manual)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ Workflow reference: [.github/workflows/README.md](.github/workflows/README.md).
 | `skip-ci` | Trivial PRs where you intentionally skip checks (jobs still report success). Remove before merge if branch protection requires green CI. |
 | `deploy-preview` | Deploy a Cloudflare preview for this PR |
 
-- **Doc-only** changes (`*.md`, `docs/`, templates): `ci.yml` does not run; `pull-request.yml` runs secret scan only.
+- **Doc-only** changes (`*.md`, `docs/`, templates): full PR checks run; heavy CI steps are skipped (fast pass).
 - **Workers-only** changes: `ci.yml` runs without Playwright; `e2e-web` does not run.
 - **Dependabot** patch/minor PRs may auto-merge when CI is green (see workflow README).
 
@@ -222,8 +222,8 @@ Labels are defined in [.github/labels.yml](.github/labels.yml) and synced via th
    - Updated documentation if needed
 
 2. PRs require:
-   - Passing CI checks (doc-only PRs skip `ci.yml`; workers-only PRs skip Playwright in `ci.yml`)
-   - **PR gate** and **Secret scan** (branch protection); code changes should also pass **Build and test**
+   - Passing CI checks (doc-only PRs skip heavy steps; workers-only PRs skip Playwright in `ci.yml`)
+   - **PR gate**, **Secret scan**, **CI gate**, and **Build and test** (branch protection)
    - Review encouraged; branch protection does not require approvals (Dependabot auto-merge)
    - No merge conflicts
 


### PR DESCRIPTION
## Summary
- **CI runs on every PR** (removed `pull_request` `paths-ignore`)
- **Doc-only PRs** skip install/typecheck/tests via `paths-filter` but still report **CI gate** + **Build and test**
- **Branch protection** updated to require **CI gate** and **Build and test** (apply via `pnpm run sync:branch-protection` after merge)

## Test plan
- [ ] PR checks green (including Build and test)
- [ ] After merge: run `pnpm run sync:branch-protection` on main


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions triggers and branch protection required checks, which can block merges or create unexpected CI load if the new doc-only detection misbehaves. No runtime/application code is affected.
> 
> **Overview**
> **CI now runs on every PR** by removing `pull_request` `paths-ignore` from `ci.yml`, and adding a `paths-filter` gate that detects doc-only PRs.
> 
> For doc-only PRs, `Build and test` exits quickly without checkout/install/tests but still reports success, while code PRs keep running the full suite (and Playwright only when web paths change).
> 
> Branch protection and contributor/maintainer docs are updated to require `CI gate` and `Build and test` (in addition to `PR gate` and `Secret scan`) on `main`/`dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ba37a02ddbc78c1a4955f362bbedc2ce38e998. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Require additional status checks on all PRs: PR gate, Secret scan, CI gate, and Build and test; doc-only PRs skip heavy CI but still report success
  * CI workflow now detects doc-only changes and conditionally skips or runs build/test and Playwright steps

* **Documentation**
  * Updated contributor and CI docs and branch-protection guidance to reflect the new behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->