### PR TITLE
chore(ci): shared path filters and auto-sync branch protection

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -25,13 +25,15 @@ Coverage artifacts are always uploaded from [coverage.yml](../workflows/coverage
 
 ## 3. Branch protection
 
-Desired rules live in [branch-protection.json](./branch-protection.json). Apply with admin `gh` access:
+Desired rules live in [branch-protection.json](./branch-protection.json). They are applied automatically on push to `main` ([sync-branch-protection.yml](./workflows/sync-branch-protection.yml)). To apply locally with admin `gh` access:
 
 ```bash
 pnpm run sync:branch-protection
 # preview payload only:
 node scripts/sync-branch-protection.mjs --dry-run
 ```
+
+Shared doc/code path rules for CI live in [path-filters.yml](./path-filters.yml).
 
 Default required checks: **PR gate**, **Secret scan**, **CI gate**, **Build and test** (all run on every PR; doc-only PRs skip heavy CI steps but still report success).
 

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,0 +1,20 @@
+# Shared filters for dorny/paths-filter (ci.yml, pull-request.yml).
+# Doc-only paths align with ci.yml push paths-ignore.
+code:
+  - '**'
+  - '!**.md'
+  - '!docs/**'
+  - '!.github/ISSUE_TEMPLATE/**'
+  - '!.github/PULL_REQUEST_TEMPLATE.md'
+  - '!.github/chatmodes/**'
+  - '!LICENSE'
+  - '!CODE_OF_CONDUCT.md'
+  - '!SECURITY.md'
+
+web:
+  - 'apps/web/**'
+  - 'packages/ui/**'
+  - 'packages/analysis/**'
+  - 'pnpm-lock.yaml'
+  - 'package.json'
+  - 'pnpm-workspace.yaml'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 | [dependabot-automerge.yml](./dependabot-automerge.yml) | Dependabot PRs | Auto-approve + squash auto-merge for **patch** and **minor** (majors need manual review) |
 | [pr-labeler.yml](./pr-labeler.yml) | Every PR | Path-based labels (`frontend`, `backend`, `analysis`, `tools`, `github-actions`) |
 | [sync-labels.yml](./sync-labels.yml) | Push to `main` when [labels.yml](../labels.yml) changes | Keeps GitHub labels in sync |
+| [sync-branch-protection.yml](./sync-branch-protection.yml) | Push to `main` when [branch-protection.json](../branch-protection.json) changes | Applies branch rules via API |
 | [stale.yml](./stale.yml) | Mon 14:00 UTC | Marks inactive issues/PRs stale (30d) and closes after 14d more |
 | [scorecard.yml](./scorecard.yml) | Mon 08:00 UTC | OpenSSF Scorecard supply-chain analysis (SARIF → Security tab) |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,50 +41,27 @@ jobs:
         with:
           pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
-      - name: Detect non-doc code changes
-        id: code-filter
+      - name: Detect path changes
+        id: paths
         uses: dorny/paths-filter@v4
         with:
-          filters: |
-            code:
-              - '**'
-              - '!**.md'
-              - '!docs/**'
-              - '!.github/ISSUE_TEMPLATE/**'
-              - '!.github/PULL_REQUEST_TEMPLATE.md'
-              - '!.github/chatmodes/**'
-              - '!LICENSE'
-              - '!CODE_OF_CONDUCT.md'
-              - '!SECURITY.md'
+          filters: .github/path-filters.yml
 
       - name: Decide code changed
         id: code
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.code-filter.outputs.code }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.paths.outputs.code }}" == "true" ]]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect web-related changes
-        id: filter
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            web:
-              - 'apps/web/**'
-              - 'packages/ui/**'
-              - 'packages/analysis/**'
-              - 'pnpm-lock.yaml'
-              - 'package.json'
-              - 'pnpm-workspace.yaml'
-
       - name: Decide Playwright smoke
         id: e2e
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.filter.outputs.web }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.paths.outputs.web }}" == "true" ]]; then
             echo "run_e2e=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,19 +32,9 @@ jobs:
 
       - name: Detect non-doc code changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
-          filters: |
-            code:
-              - '**'
-              - '!**.md'
-              - '!docs/**'
-              - '!.github/ISSUE_TEMPLATE/**'
-              - '!.github/PULL_REQUEST_TEMPLATE.md'
-              - '!.github/chatmodes/**'
-              - '!LICENSE'
-              - '!CODE_OF_CONDUCT.md'
-              - '!SECURITY.md'
+          filters: .github/path-filters.yml
 
   duplicate-check:
     name: Duplicate file check

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -1,0 +1,30 @@
+name: Sync branch protection
+
+# Applies .github/branch-protection.json when it changes on main.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/branch-protection.json'
+      - 'scripts/sync-branch-protection.mjs'
+  workflow_dispatch:
+
+permissions:
+  administration: write
+
+concurrency:
+  group: sync-branch-protection-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Apply branch protection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Apply protection rules
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/sync-branch-protection.mjs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/blakeox/financial-analysis/actions/workflows/ci.yml/badge.svg)
 ![CI Pipeline](https://github.com/blakeox/financial-analysis/actions/workflows/ci-cd.yml/badge.svg)
+![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/blakeox/financial-analysis/badge)
 ![License: MIT](https://img.shields.io/github/license/blakeox/financial-analysis)
 ![GitHub contributors](https://img.shields.io/github/contributors/blakeox/financial-analysis)
 


### PR DESCRIPTION
## Summary
- **`.github/path-filters.yml`** — single source for doc-only vs code vs web paths (`ci.yml`, `pull-request.yml`)
- **`sync-branch-protection.yml`** — applies `branch-protection.json` on push to `main`
- OpenSSF **Scorecard badge** on README
- `pull-request.yml` paths-filter upgraded to v4

## Test plan
- [ ] CI + PR checks green
- [ ] After merge, sync workflow runs when branch-protection.json is touched


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI gating logic (doc-only vs code/web detection) and introduces an Actions workflow with `administration: write` that can modify branch protection settings on `main` pushes.
> 
> **Overview**
> **CI path detection is centralized** by introducing `.github/path-filters.yml` and updating `ci.yml` and `pull-request.yml` to use it (and bumping `pull-request.yml` to `dorny/paths-filter@v4`), removing duplicated inline filters.
> 
> **Branch protection is now auto-applied** via a new `sync-branch-protection.yml` workflow that runs on `main` when `branch-protection.json` or `scripts/sync-branch-protection.mjs` change, and maintainer docs are updated accordingly.
> 
> Adds an OpenSSF Scorecard badge to `README.md` and documents the new workflow in `.github/workflows/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ff4f982eed0cf544274ae1a6d5a1f401097149. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->