### PR TITLE
feat(ci): require E2E smoke and CodeQL on every PR

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -35,7 +35,7 @@ node scripts/sync-branch-protection.mjs --dry-run
 
 Shared doc/code path rules for CI live in [path-filters.yml](./path-filters.yml).
 
-Default required checks: **PR gate**, **Secret scan**, **CI gate**, **Build and test** (all run on every PR; doc-only PRs skip heavy CI steps but still report success).
+Default required checks: **PR gate**, **Secret scan**, **CI gate**, **Build and test**, **E2E smoke**, **CodeQL** (all run on every PR; doc-only/workers-only PRs skip heavy steps but still report success).
 
 ## 4. Auto-merge and Dependabot
 

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -13,10 +13,18 @@
   },
   "required_status_checks": {
     "strict": true,
-    "contexts": ["PR gate", "Secret scan", "CI gate", "Build and test"]
+    "contexts": [
+      "PR gate",
+      "Secret scan",
+      "CI gate",
+      "Build and test",
+      "E2E smoke",
+      "CodeQL"
+    ]
   },
   "notes": [
-    "All four checks run on every PR. Doc-only PRs skip heavy CI steps but still report Build and test success.",
+    "All checks run on every PR. Doc-only and workers-only PRs skip heavy steps but still report success.",
+    "E2E smoke runs Playwright when web paths change; CodeQL runs when non-doc code changes.",
     "Push to main/dev with doc-only paths still skips ci.yml via paths-ignore on push."
   ]
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,8 @@ Overview of CI/CD for the `financial-analysis` monorepo. All install jobs use [s
 |----------|----------------|--------------|
 | [ci.yml](./ci.yml) | Every PR; push when not doc-only `paths-ignore` | Duplicates (push only), smoke, typecheck, lint, format, audit, unit tests; Playwright when web paths change; doc-only PRs skip heavy steps |
 | [pull-request.yml](./pull-request.yml) | Every PR | Duplicate check, dependency review, TruffleHog secret scan |
-| [e2e-web.yml](./e2e-web.yml) | PRs touching `apps/web`, `packages/ui`, `packages/analysis`, lockfile, or this workflow | Playwright smoke-matrix (chromium + firefox + webkit + mobile-safari) |
+| [e2e-web.yml](./e2e-web.yml) | Every PR (Playwright when web paths change) | **E2E smoke** — smoke-matrix on web PRs; fast pass otherwise |
+| [codeql.yml](./codeql.yml) | Every PR + push to `main`/`dev` | **CodeQL** — analysis when code changes; fast pass on doc-only PRs |
 | [dependabot-automerge.yml](./dependabot-automerge.yml) | Dependabot PRs | Auto-approve + squash auto-merge for **patch** and **minor** (majors need manual review) |
 | [pr-labeler.yml](./pr-labeler.yml) | Every PR | Path-based labels (`frontend`, `backend`, `analysis`, `tools`, `github-actions`) |
 | [sync-labels.yml](./sync-labels.yml) | Push to `main` when [labels.yml](../labels.yml) changes | Keeps GitHub labels in sync |
@@ -58,7 +59,7 @@ Canonical definitions live in [.github/labels.yml](../labels.yml). After merging
 
 `ci.yml` skips **Playwright** when the diff has no web-related paths (`apps/web`, `packages/ui`, `packages/analysis`, root lockfile/workspace manifests). Workers-only changes still run API smoke, typecheck, lint, format, audit, and unit tests.
 
-`e2e-web.yml` only triggers on web-related paths (see workflow `paths` filter).
+`e2e-web.yml` runs on every PR; Playwright runs only when web-related paths change.
 
 ### Doc-only
 
@@ -85,7 +86,7 @@ Full steps: [.github/MAINTAINER_SETUP.md](../MAINTAINER_SETUP.md).
 
 1. **General → Allow auto-merge** — required for Dependabot auto-merge
 2. **Actions → Run workflows from Dependabot pull requests** — full CI on dependency PRs
-3. **Branch protection** — `pnpm run sync:branch-protection` applies [.github/branch-protection.json](../branch-protection.json) (`PR gate`, `Secret scan`, `CI gate`, `Build and test`)
+3. **Branch protection** — auto-synced from [.github/branch-protection.json](../branch-protection.json) (`PR gate`, `Secret scan`, `CI gate`, `Build and test`, `E2E smoke`, `CodeQL`)
 4. **Secrets** — Cloudflare tokens for deploy; optional `CODECOV_TOKEN`; Slack for monitors
 5. **Environments** — `preview` / `production` with protection rules if using deploy workflows
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,7 +106,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      security-events: write
 
     steps:
       - name: Checkout code
@@ -117,11 +116,3 @@ jobs:
 
       - name: Run security audit
         run: pnpm audit --audit-level moderate
-
-      - name: Run CodeQL Analysis
-        uses: github/codeql-action/init@v4
-        with:
-          languages: javascript-typescript
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect skip-ci label
+        if: github.event_name == 'pull_request'
+        id: skip
+        uses: ./.github/actions/pr-skip-ci
+        with:
+          pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+      - name: Detect path changes
+        if: github.event_name == 'pull_request'
+        id: paths
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/path-filters.yml
+
+      - name: Skipped (doc-only or skip-ci)
+        if: |
+          github.event_name == 'pull_request' && (
+            steps.skip.outputs.skip_ci == 'true' ||
+            steps.paths.outputs.code != 'true'
+          )
+        run: echo "CodeQL skipped — doc-only PR or skip-ci label."
+
+      - name: Initialize CodeQL
+        if: |
+          github.event_name != 'pull_request' || (
+            steps.skip.outputs.skip_ci != 'true' &&
+            steps.paths.outputs.code == 'true'
+          )
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        if: |
+          github.event_name != 'pull_request' || (
+            steps.skip.outputs.skip_ci != 'true' &&
+            steps.paths.outputs.code == 'true'
+          )
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -3,13 +3,6 @@ name: E2E Web
 on:
   pull_request:
     branches: [main, dev]
-    paths:
-      - 'apps/web/**'
-      - 'packages/ui/**'
-      - 'packages/analysis/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/e2e-web.yml'
-      - '.github/actions/**'
   schedule:
     # Weekly extended web smoke (Mon 12:00 UTC)
     - cron: '0 12 * * 1'
@@ -54,11 +47,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gate:
+  e2e-smoke:
+    name: E2E smoke
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    outputs:
-      skip_ci: ${{ steps.skip.outputs.skip_ci }}
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -69,11 +62,57 @@ jobs:
         with:
           pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
+      - name: Detect path changes
+        id: paths
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/path-filters.yml
+
+      - name: Skipped (skip-ci label)
+        if: steps.skip.outputs.skip_ci == 'true'
+        run: echo "E2E skipped via skip-ci label."
+
+      - name: Skipped (no web-related paths)
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web != 'true'
+        run: echo "E2E skipped — no web-related paths changed."
+
+      - name: Setup monorepo
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Build shared packages
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        run: pnpm run build:libs
+
+      - name: Install Playwright Browsers
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        working-directory: apps/web
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Build web
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        working-directory: apps/web
+        run: pnpm build
+
+      - name: Run web smoke matrix lane
+        if: steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        working-directory: apps/web
+        run: pnpm run test:ci:smoke:matrix
+
+      - name: Upload smoke matrix Playwright artifacts
+        if: always() && steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-smoke-matrix-artifacts
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results/playwright
+          retention-days: 7
+
   smoke:
-    needs: [gate]
-    if: |
-      always() &&
-      (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke'))
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -111,11 +150,7 @@ jobs:
           retention-days: 7
 
   smoke-matrix:
-    needs: [gate]
-    if: |
-      always() &&
-      (github.event_name != 'pull_request' || (needs.gate.result == 'success' && needs.gate.outputs.skip_ci != 'true')) &&
-      (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke-matrix'))
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'smoke-matrix'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 ## CI (do not duplicate locally)
 
 - Workflows use `.github/actions/setup-monorepo` for pnpm + Node 22 + install
-- **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web` (web paths only)
+- **PR / `dev` push:** `ci.yml`, `pull-request.yml`, `e2e-web`, `codeql.yml` (E2E/CodeQL skip heavy steps when paths unchanged)
 - **Doc-only PRs:** `ci.yml` runs but skips install/tests; `pull-request.yml` skips duplicate/dependency review
-- **Workers-only PRs:** full `ci.yml` minus Playwright; no `e2e-web`
+- **Workers-only PRs:** full `ci.yml` minus Playwright; **E2E smoke** fast pass
 - **Labels:** `skip-ci` (skip all PR checks), `deploy-preview` (preview deploy)
 - **Dependabot:** patch/minor auto-merge via `dependabot-automerge.yml` (majors manual)
 - **Workflow map:** [.github/workflows/README.md](.github/workflows/README.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 - **Dependabot:** patch/minor auto-merge via `dependabot-automerge.yml` (majors manual)
 - **Workflow map:** [.github/workflows/README.md](.github/workflows/README.md)
 - **Maintainer setup:** [.github/MAINTAINER_SETUP.md](.github/MAINTAINER_SETUP.md) (Codecov, Dependabot workflows, branch protection sync)
-- **`main` push only:** `ci-cd.yml` (artifacts, CodeQL)
+- **`main` push only:** `ci-cd.yml` (artifacts)
 - **Security:** OpenSSF Scorecard in `scorecard.yml` (weekly + Security tab SARIF)
 - **Never commit:** Finder duplicates (`file 2`), flat Playwright specs, or `tests/utils/nav.ts` (use `tests/_shared/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Labels are defined in [.github/labels.yml](.github/labels.yml) and synced via th
 
 2. PRs require:
    - Passing CI checks (doc-only PRs skip heavy steps; workers-only PRs skip Playwright in `ci.yml`)
-   - **PR gate**, **Secret scan**, **CI gate**, and **Build and test** (branch protection)
+   - **PR gate**, **Secret scan**, **CI gate**, **Build and test**, **E2E smoke**, and **CodeQL** (branch protection)
    - Review encouraged; branch protection does not require approvals (Dependabot auto-merge)
    - No merge conflicts
 


### PR DESCRIPTION
## Summary
- **E2E smoke** runs on every PR; Playwright smoke-matrix when web paths change, fast pass otherwise
- **CodeQL** workflow for PRs and pushes; skips analysis on doc-only PRs
- Branch protection extended to require both checks (auto-sync via `sync-branch-protection.yml` on merge)

## Test plan
- [ ] All six required checks green on this PR
- [ ] E2E smoke and CodeQL complete (this PR has code + web paths)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes branch protection required checks and PR CI behavior; misconfiguration could block merges or add unexpected CI load, though changes are limited to GitHub Actions/config.
> 
> **Overview**
> **Adds two new required PR checks:** **E2E smoke** and **CodeQL**, and updates branch protection/docs to require them alongside existing CI gates.
> 
> `e2e-web.yml` now triggers on every PR and *fast-passes* unless web-related paths changed (or `skip-ci` is set), while a new `codeql.yml` workflow runs on PRs/pushes (and a weekly schedule) and skips analysis on doc-only PRs via `path-filters.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ac62063aac25226b5afb909fcf91a18e4f871d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR requirement docs and workflow README to list new required checks (E2E smoke, CodeQL) and explain when heavy steps run or are skipped.
  * Clarified CI guidance and contributor instructions to reflect new behaviors.

* **New Features**
  * Added a CodeQL analysis workflow that runs on PRs, pushes, and a weekly schedule.

* **Chores**
  * Enforced E2E smoke and CodeQL in branch protection.
  * Adjusted E2E workflow to run a lightweight smoke job on PRs with path-based skipping; moved full CodeQL out of the main CI security job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->