### PR TITLE
fix(ci): branch protection sync workflow permissions

### DIFF
--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -21,6 +21,7 @@ jobs:
     name: Apply branch protection
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       administration: write
     steps:
       - name: Checkout

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  administration: write
+  contents: read
 
 concurrency:
   group: sync-branch-protection-${{ github.ref }}
@@ -20,6 +20,8 @@ jobs:
   sync:
     name: Apply branch protection
     runs-on: ubuntu-latest
+    permissions:
+      administration: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Move administration: write to job level so sync-branch-protection.yml runs successfully.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions `permissions` scoping for the branch-protection sync workflow, with no production code or data-path changes.
> 
> **Overview**
> Fixes the `sync-branch-protection.yml` workflow by **scoping `administration: write` to the `sync` job** (so the branch-protection API call has the required access) while keeping workflow-wide permissions minimal with `contents: read` for checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166dc2b1cbb83b5cbc66b5e8e802df0133fcb6e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->