### PR TITLE
fix(ci): repair sync-branch-protection workflow YAML

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -25,7 +25,7 @@ Coverage artifacts are always uploaded from [coverage.yml](../workflows/coverage
 
 ## 3. Branch protection
 
-Desired rules live in [branch-protection.json](./branch-protection.json). They are applied automatically on push to `main` ([sync-branch-protection.yml](./workflows/sync-branch-protection.yml)). To apply locally with admin `gh` access:
+Desired rules live in [branch-protection.json](./branch-protection.json). On push to `main`, [sync-branch-protection.yml](./workflows/sync-branch-protection.yml) applies them when **`REPO_ADMIN_TOKEN`** is set (fine-grained PAT with **Administration: read and write**). Otherwise apply locally with admin `gh` access:
 
 ```bash
 pnpm run sync:branch-protection

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -1,6 +1,8 @@
 name: Sync branch protection
 
 # Applies .github/branch-protection.json when it changes on main.
+# GITHUB_TOKEN cannot update branch protection; set REPO_ADMIN_TOKEN (fine-grained PAT
+# with Administration: read/write) or run `pnpm run sync:branch-protection` locally.
 on:
   push:
     branches: [main]
@@ -20,14 +22,17 @@ jobs:
   sync:
     name: Apply branch protection
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      administration: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Apply protection rules
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: node scripts/sync-branch-protection.mjs
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
+        run: |
+          if node scripts/sync-branch-protection.mjs; then
+            echo "Branch protection applied."
+          else
+            echo "::warning::Could not apply branch protection via API. Add REPO_ADMIN_TOKEN (admin PAT) or run: pnpm run sync:branch-protection"
+            exit 1
+          fi


### PR DESCRIPTION
GITHUB_TOKEN workflow permissions do not support `administration`. Use optional REPO_ADMIN_TOKEN or run sync locally.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; affects only the automation that applies branch protection rules and may fail if `REPO_ADMIN_TOKEN` is not configured.
> 
> **Overview**
> Updates the `sync-branch-protection` GitHub Actions workflow to use `secrets.REPO_ADMIN_TOKEN` (fine-grained PAT with admin rights) when available, since `GITHUB_TOKEN` cannot modify branch protection, and fails with a clear warning if the API call cannot be applied.
> 
> Documentation in `MAINTAINER_SETUP.md` is updated to describe the new token requirement and the local fallback command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85446ab1f9dcea56a07d3e204fc6eb2b376c9f49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->