### PR TITLE
fix(ci): soft-fail branch protection sync without admin token

### DIFF
--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -28,11 +28,15 @@ jobs:
 
       - name: Apply protection rules
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
+          REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
+          if [[ -n "$REPO_ADMIN_TOKEN" ]]; then
+            export GH_TOKEN="$REPO_ADMIN_TOKEN"
+          else
+            export GH_TOKEN="${{ github.token }}"
+          fi
           if node scripts/sync-branch-protection.mjs; then
             echo "Branch protection applied."
           else
             echo "::warning::Could not apply branch protection via API. Add REPO_ADMIN_TOKEN (admin PAT) or run: pnpm run sync:branch-protection"
-            exit 1
           fi

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -32,11 +32,13 @@ jobs:
         run: |
           if [[ -n "$REPO_ADMIN_TOKEN" ]]; then
             export GH_TOKEN="$REPO_ADMIN_TOKEN"
-          else
-            export GH_TOKEN="${{ github.token }}"
-          fi
-          if node scripts/sync-branch-protection.mjs; then
+            node scripts/sync-branch-protection.mjs
             echo "Branch protection applied."
           else
-            echo "::warning::Could not apply branch protection via API. Add REPO_ADMIN_TOKEN (admin PAT) or run: pnpm run sync:branch-protection"
+            export GH_TOKEN="${{ github.token }}"
+            if node scripts/sync-branch-protection.mjs; then
+              echo "Branch protection applied."
+            else
+              echo "::warning::Could not apply branch protection via API. Add REPO_ADMIN_TOKEN (admin PAT) or run: pnpm run sync:branch-protection"
+            fi
           fi


### PR DESCRIPTION
Sync workflow parses and runs; without REPO_ADMIN_TOKEN it logs a warning instead of failing main.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: the workflow now falls back to `github.token` and logs a warning instead of failing the job when an admin PAT isn’t provided, so it won’t block `main` but could let branch protection drift until manually applied.
> 
> **Overview**
> The branch-protection sync workflow now **conditionally uses** `REPO_ADMIN_TOKEN` when present, otherwise falls back to `github.token` by exporting `GH_TOKEN` in the script.
> 
> If applying protection rules fails (e.g., due to missing admin permissions), the job now **soft-fails** by emitting a `::warning::` instead of exiting non-zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed783e67e1f4421bd07aa4de8cb2494641cc43f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->