### PR TITLE
docs: REPO_ADMIN_TOKEN setup

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -25,7 +25,18 @@ Coverage artifacts are always uploaded from [coverage.yml](../workflows/coverage
 
 ## 3. Branch protection
 
-Desired rules live in [branch-protection.json](./branch-protection.json). On push to `main`, [sync-branch-protection.yml](./workflows/sync-branch-protection.yml) applies them when **`REPO_ADMIN_TOKEN`** is set (fine-grained PAT with **Administration: read and write**). Otherwise apply locally with admin `gh` access:
+Desired rules live in [branch-protection.json](./branch-protection.json). On push to `main`, [sync-branch-protection.yml](./workflows/sync-branch-protection.yml) applies them when **`REPO_ADMIN_TOKEN`** is set.
+
+**Set or rotate the secret** (repo admin; token needs permission to update branch protection):
+
+```bash
+# Classic gh CLI token with repo scope (repo owner/admin):
+gh secret set REPO_ADMIN_TOKEN --repo blakeox/financial-analysis --body "$(gh auth token)"
+
+# Or use a fine-grained PAT with Administration: read and write on this repository.
+```
+
+Without the secret, apply locally:
 
 ```bash
 pnpm run sync:branch-protection


### PR DESCRIPTION
Documents how the repo secret was configured for branch protection auto-sync.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change describing how to set/rotate a GitHub Actions secret; no runtime or workflow logic is modified.
> 
> **Overview**
> Updates `.github/MAINTAINER_SETUP.md` to clarify how branch protection auto-sync works when `REPO_ADMIN_TOKEN` is present, and adds copy-pastable `gh secret set` instructions for setting/rotating that secret.
> 
> Also rephrases the fallback guidance for applying branch protection locally when the secret is not configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b179f1fdc001872848384339dcc8e65b937886c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->