### PR TITLE
chore: sync dev with main (dependabot fetch-metadata v3)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Dependabot metadata (pull_request_target only)
         if: steps.author.outputs.skip != 'true' && github.event_name == 'pull_request_target'
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
Fast-forward `dev` after #286 (dependabot/fetch-metadata@v3).

No file changes expected beyond merge commit if trees already match.

## Test plan
- [ ] CI green
- [ ] Merge

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to a workflow dependency version bump; main risk is any behavioral differences in `fetch-metadata@v3` affecting auto-merge gating.
> 
> **Overview**
> Updates the Dependabot auto-merge workflow to pull metadata via `dependabot/fetch-metadata@v3` (from `@v2`), keeping the same auto-merge logic while aligning with the newer action release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff32106828640f5185a4df753774930b6db8730. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->