### PR TITLE
chore: sync dev with main (branching docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,19 @@ If you see a build loop, ensure `.astro/` and `dist/` are ignored (see `apps/web
 7. Push to your fork: `git push origin feature/your-feature-name`
 8. Create a Pull Request
 
+### Branching model
+
+Only two long-lived branches exist on the upstream repo:
+
+| Branch | Role |
+|--------|------|
+| **`main`** | Default branch; production-oriented merges and Dependabot targets. Protected with required CI. |
+| **`dev`** | Integration branch; should match **`main`** in tree content after each sync. CI runs on PRs to `dev` the same as `main`. |
+
+**Day-to-day work:** branch from `dev` (or `main` if you only touch docs), open a PR into **`main`** for features and fixes. After merging to `main`, sync `dev` with a PR from `main` → `dev` (or ask a maintainer) so both tips stay aligned.
+
+**Short-lived branches:** use `feat/`, `fix/`, or `chore/` prefixes. Delete the branch when the PR merges (GitHub “Delete branch”).
+
 ## Coding Standards
 
 ### General Principles


### PR DESCRIPTION
Sync dev after #295.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that doesn’t affect runtime behavior or CI configuration.
> 
> **Overview**
> Adds a new **Branching model** section to `CONTRIBUTING.md` documenting the two long-lived branches (`main` and `dev`), the expected sync flow (`main` → `dev` after merges), and naming/cleanup guidance for short-lived feature/fix/chore branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a57c19d7494ba0db39cd5acf069cd036a92473. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->