### PR TITLE
chore: sync dev with main (branching docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,19 @@ If you see a build loop, ensure `.astro/` and `dist/` are ignored (see `apps/web
 7. Push to your fork: `git push origin feature/your-feature-name`
 8. Create a Pull Request
 
+### Branching model
+
+Only two long-lived branches exist on the upstream repo:
+
+| Branch | Role |
+|--------|------|
+| **`main`** | Default branch; production-oriented merges and Dependabot targets. Protected with required CI. |
+| **`dev`** | Integration branch; should match **`main`** in tree content after each sync. CI runs on PRs to `dev` the same as `main`. |
+
+**Day-to-day work:** branch from `dev` (or `main` if you only touch docs), open a PR into **`main`** for features and fixes. After merging to `main`, sync `dev` with a PR from `main` → `dev` (or ask a maintainer) so both tips stay aligned.
+
+**Short-lived branches:** use `feat/`, `fix/`, or `chore/` prefixes. Delete the branch when the PR merges (GitHub “Delete branch”).
+
 ## Coding Standards
 
 ### General Principles


### PR DESCRIPTION
Merge main into dev after #295.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies branching and PR flow; no runtime or CI behavior is modified.
> 
> **Overview**
> Updates `CONTRIBUTING.md` to add a **branching model** section documenting the roles of `main` and `dev`, the expected `main` → `dev` sync workflow after merges, and conventions for short-lived branch prefixes and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c80a33a3301ceb62e3db9f78a71534ed7a5932. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->