### PR TITLE
chore(ci): allow workflow_dispatch on ci-cd push jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
   # Quality Checks
   quality:
     name: Code Quality
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -48,7 +48,7 @@ jobs:
   # Workspace Tests
   test:
     name: Workspace Tests
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -68,7 +68,7 @@ jobs:
   # Build
   build:
     name: Build
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [quality, test]
@@ -110,7 +110,8 @@ jobs:
     needs: [quality]
     if: >-
       github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && needs.quality.result == 'success')
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      needs.quality.result == 'success')
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary
- Align `main` with `dev` for `ci-cd.yml` so manual workflow runs can execute quality/test/build jobs.

## Test plan
- [ ] CI gate passes (workflow-only change)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to job conditions; no application or deployment logic affected.
> 
> **Overview**
> Manual **Run workflow** on `ci-cd.yml` now runs the same jobs as a `main` push. Job `if` conditions on **quality**, **test**, **build**, and **security** (after quality succeeds) now allow `workflow_dispatch` in addition to `push`.
> 
> Previously, `workflow_dispatch` was in the trigger list but those jobs still required `push`, so a manual run would not execute the full pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ecc854e73139d749a0ad7deba5482a3a75ada8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->