### PR TITLE
chore(security): pin Actions, harden workflows, and clear CodeQL findings

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -7,8 +7,8 @@
   "allow_force_pushes": false,
   "allow_deletions": false,
   "required_pull_request_reviews": {
-    "required_approving_review_count": 0,
-    "dismiss_stale_reviews": false,
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false
   },
   "required_status_checks": {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -93,7 +93,7 @@ jobs:
           pnpm --filter @financial-analysis/api run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-artifacts
           path: |
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run_e2e: ${{ steps.e2e.outputs.run_e2e }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Detect skip-ci label
         id: skip
@@ -43,7 +43,7 @@ jobs:
 
       - name: Detect path changes
         id: paths
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: .github/path-filters.yml
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Checkout
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
@@ -23,9 +21,13 @@ jobs:
     name: CodeQL
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Detect skip-ci label
         if: github.event_name == 'pull_request'
@@ -37,7 +39,7 @@ jobs:
       - name: Detect path changes
         if: github.event_name == 'pull_request'
         id: paths
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: .github/path-filters.yml
 
@@ -55,7 +57,7 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
         with:
           languages: javascript-typescript
 
@@ -65,4 +67,4 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: coverage-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -48,7 +51,7 @@ jobs:
 
       - name: Upload coverage (Codecov)
         if: steps.codecov.outputs.enabled == 'true'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: packages/analysis/coverage/coverage-final.json
           fail_ci_if_error: false
@@ -61,7 +64,7 @@ jobs:
 
       - name: Upload analysis coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: analysis-coverage
           path: packages/analysis/coverage
@@ -71,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -95,7 +98,7 @@ jobs:
 
       - name: Upload web coverage (Codecov)
         if: steps.codecov.outputs.enabled == 'true'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: apps/web/coverage/vitest/lcov.info
           fail_ci_if_error: false
@@ -108,7 +111,7 @@ jobs:
 
       - name: Upload web coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-coverage
           path: apps/web/coverage/vitest

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -12,13 +12,15 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dependabot-automerge:
     name: Auto-merge Dependabot (patch/minor)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: |
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
       (github.event_name == 'workflow_run' &&
@@ -59,7 +61,7 @@ jobs:
       - name: Dependabot metadata (pull_request_target only)
         if: steps.author.outputs.skip != 'true' && github.event_name == 'pull_request_target'
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -26,7 +26,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,7 +27,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Detect skip-ci label
         id: skip
@@ -64,7 +64,7 @@ jobs:
 
       - name: Detect path changes
         id: paths
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: .github/path-filters.yml
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload smoke matrix Playwright artifacts
         if: always() && steps.skip.outputs.skip_ci != 'true' && steps.paths.outputs.web == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-smoke-matrix-artifacts
           path: |
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload smoke Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-smoke-artifacts
           path: |
@@ -155,7 +155,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload smoke matrix Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-smoke-matrix-artifacts
           path: |
@@ -197,7 +197,7 @@ jobs:
         project: [chromium, firefox, webkit, mobile-safari]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload full matrix Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-full-${{ matrix.project }}
           path: |
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
@@ -259,7 +259,7 @@ jobs:
 
       - name: Upload flake repro Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-flake-repro
           path: |

--- a/.github/workflows/monitor-r2-quotas.yml
+++ b/.github/workflows/monitor-r2-quotas.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create or update GitHub Issue
         if: failure() && steps.precheck.outputs.skip != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -126,8 +126,13 @@ jobs:
             const existing = issues.find(i => i.title.startsWith('R2 quota alert'));
 
             if (existing) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
-              core.info(`Commented on existing issue #${existing.number}`);
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.info(`Updated existing issue #${existing.number}`);
             } else {
               const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
               core.info(`Created issue #${created.data.number}`);

--- a/.github/workflows/monitor-workers-health.yml
+++ b/.github/workflows/monitor-workers-health.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Create or update GitHub Issue
         if: failure() && steps.precheck.outputs.skip != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -116,8 +116,13 @@ jobs:
             const { data: issues } = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: label });
             const existing = issues.find(i => i.title.startsWith('Workers health alert'));
             if (existing) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
-              core.info(`Commented on existing issue #${existing.number}`);
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.info(`Updated existing issue #${existing.number}`);
             } else {
               const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
               core.info(`Created issue #${created.data.number}`);

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 8 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: mutation-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Apply path-based labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  security-events: write
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -58,6 +57,10 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
     steps:
       - name: Skipped (skip-ci or docs-only)
         if: needs.gate.outputs.skip_ci == 'true' || needs.gate.outputs.code_changed != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -40,7 +43,7 @@ jobs:
 
       - name: Create Release PR with Changesets
         if: steps.pending.outputs.found == 'true'
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           version: pnpm -w changeset version
           # Monorepo is not published to npm; version PR only.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,18 +35,18 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark and close stale items
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: pinned,security,dependencies
+          exempt-issue-labels: pinned,security,dependencies,alert:workers-errors,alert:R2-quota
           exempt-pr-labels: pinned,security,dependencies,skip-ci
           stale-issue-message: This issue has been inactive for 30 days and will be closed in 14 days unless there is new activity.
           stale-pr-message: This pull request has been inactive for 30 days and will be closed in 14 days unless there is new activity.

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Apply protection rules
         env:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Sync labels from .github/labels.yml
-        uses: micnncim/action-label-syncer@v1
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prune: false

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -24,8 +24,18 @@ export default defineConfig({
       lastmod: new Date(),
       // Custom priority and changefreq based on page importance
       serialize(item) {
+        let isHomepage = false;
+        try {
+          const parsed = new URL(item.url);
+          isHomepage =
+            parsed.hostname === 'fanalyx.com' &&
+            (parsed.pathname === '/' || parsed.pathname === '');
+        } catch {
+          isHomepage = false;
+        }
+
         // Homepage - highest priority
-        if (item.url === 'https://fanalyx.com/' || item.url.endsWith('fanalyx.com/')) {
+        if (isHomepage) {
           item.priority = 1.0;
           item.changefreq = 'daily';
         }

--- a/apps/web/src/scripts/analytics/chat-analytics.ts
+++ b/apps/web/src/scripts/analytics/chat-analytics.ts
@@ -77,7 +77,7 @@ class ChatAnalyticsCollector {
   }
 
   private generateSessionId(): string {
-    return `chat_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    return `chat_${crypto.randomUUID()}`;
   }
 
   private setupEventListeners(): void {

--- a/apps/web/src/scripts/chat/chat-memory.ts
+++ b/apps/web/src/scripts/chat/chat-memory.ts
@@ -396,7 +396,7 @@ class ChatMemoryManager {
    * Generate unique session ID
    */
   private generateSessionId(): string {
-    const randomSuffix = Math.random().toString(36).slice(2, 11);
+    const randomSuffix = crypto.randomUUID().replace(/-/g, '').slice(0, 9);
     return `session_${Date.now()}_${randomSuffix}`;
   }
 

--- a/apps/web/src/scripts/chat/chat-panel.ts
+++ b/apps/web/src/scripts/chat/chat-panel.ts
@@ -1015,12 +1015,8 @@ class ChatPanel {
     const contentDiv = document.createElement('div');
     contentDiv.className = 'message-content';
 
-    // Sanitize user messages to prevent XSS
-    if (type === 'user') {
-      contentDiv.textContent = content; // Use textContent for user messages (auto-escapes)
-    } else {
-      contentDiv.innerHTML = content; // Assistant messages can have formatted HTML
-    }
+    contentDiv.textContent = content;
+    contentDiv.style.whiteSpace = 'pre-wrap';
 
     messageDiv.appendChild(contentDiv);
     this.messages.appendChild(messageDiv);
@@ -1041,8 +1037,8 @@ class ChatPanel {
     if (lastMessage && lastMessage.classList.contains('assistant')) {
       const contentDiv = lastMessage.querySelector('.message-content');
       if (contentDiv) {
-        // Simple formatting for streaming text
-        contentDiv.innerHTML = content.replace(/\n/g, '<br>');
+        contentDiv.textContent = content;
+        (contentDiv as HTMLElement).style.whiteSpace = 'pre-wrap';
         this.messages.scrollTop = this.messages.scrollHeight;
       }
     }

--- a/packages/ui/src/components/LeaseAnalysisDashboard.tsx
+++ b/packages/ui/src/components/LeaseAnalysisDashboard.tsx
@@ -1301,7 +1301,7 @@ export function LeaseAnalysisDashboard({
     const printWindow = window.open('', '_blank');
     if (!printWindow) return;
 
-    const html = (value: string) => escapeHtml(value);
+    const escaped = (value: string) => escapeHtml(value);
 
     printWindow.document.write(`
       <html>
@@ -1321,33 +1321,33 @@ export function LeaseAnalysisDashboard({
         </head>
         <body>
           <h1>Lease Analysis Report</h1>
-          <p>Generated on ${html(new Date().toLocaleDateString())}</p>
+          <p>Generated on ${escaped(new Date().toLocaleDateString())}</p>
           
           <h2>Financial Summary</h2>
           <div class="summary">
             <div class="metric">
-              <div class="metric-value">${html(formatCurrency(result.metrics.averageMonthlyPayment))}</div>
+              <div class="metric-value">${escaped(formatCurrency(result.metrics.averageMonthlyPayment))}</div>
               <div>Avg Monthly Payment</div>
             </div>
             <div class="metric">
-              <div class="metric-value">${html(formatCurrency(result.metrics.totalCost))}</div>
+              <div class="metric-value">${escaped(formatCurrency(result.metrics.totalCost))}</div>
               <div>Total Cost</div>
             </div>
             <div class="metric">
-              <div class="metric-value">${html(formatCurrency(result.metrics.presentValue))}</div>
+              <div class="metric-value">${escaped(formatCurrency(result.metrics.presentValue))}</div>
               <div>Present Value</div>
             </div>
             <div class="metric">
-              <div class="metric-value">${html(formatPercentage(result.metrics.effectiveAnnualRate))}</div>
+              <div class="metric-value">${escaped(formatPercentage(result.metrics.effectiveAnnualRate))}</div>
               <div>Effective Rate</div>
             </div>
           </div>
 
           <h2>Risk Assessment</h2>
           <table class="table">
-            <tr><td>Flexibility Score</td><td>${html(String(result.riskAnalysis.flexibilityScore))}/100</td></tr>
-            <tr><td>Early Termination Cost</td><td>${html(formatCurrency(result.riskAnalysis.earlyTerminationCost))}</td></tr>
-            <tr><td>Renewal Risk</td><td>${html(result.riskAnalysis.renewalRisk)}</td></tr>
+            <tr><td>Flexibility Score</td><td>${escaped(String(result.riskAnalysis.flexibilityScore))}/100</td></tr>
+            <tr><td>Early Termination Cost</td><td>${escaped(formatCurrency(result.riskAnalysis.earlyTerminationCost))}</td></tr>
+            <tr><td>Renewal Risk</td><td>${escaped(result.riskAnalysis.renewalRisk)}</td></tr>
           </table>
 
           ${
@@ -1355,12 +1355,12 @@ export function LeaseAnalysisDashboard({
               ? `
             <h2>Lease vs Buy Comparison</h2>
             <div class="recommendation">
-              <strong>Recommendation: ${html(result.leaseVsBuy.recommendation.toUpperCase())}</strong>
+              <strong>Recommendation: ${escaped(result.leaseVsBuy.recommendation.toUpperCase())}</strong>
             </div>
             <table class="table">
               <tr><th>Option</th><th>Total Cost</th><th>Monthly Payment</th></tr>
-              <tr><td>Lease</td><td>${html(formatCurrency(result.leaseVsBuy.leaseOption.totalCost))}</td><td>${html(formatCurrency(result.leaseVsBuy.leaseOption.monthlyPayment))}</td></tr>
-              <tr><td>Buy</td><td>${html(formatCurrency(result.leaseVsBuy.buyOption.totalLoanCost))}</td><td>${html(formatCurrency(result.leaseVsBuy.buyOption.loanPayment))}</td></tr>
+              <tr><td>Lease</td><td>${escaped(formatCurrency(result.leaseVsBuy.leaseOption.totalCost))}</td><td>${escaped(formatCurrency(result.leaseVsBuy.leaseOption.monthlyPayment))}</td></tr>
+              <tr><td>Buy</td><td>${escaped(formatCurrency(result.leaseVsBuy.buyOption.totalLoanCost))}</td><td>${escaped(formatCurrency(result.leaseVsBuy.buyOption.loanPayment))}</td></tr>
             </table>
           `
               : ''
@@ -1374,11 +1374,11 @@ export function LeaseAnalysisDashboard({
               .map(
                 (payment) => `
               <tr>
-                <td>${html(String(payment.month))}</td>
-                <td>${html(formatCurrency(payment.escalatedPayment))}</td>
-                <td>${html(formatCurrency(payment.additionalCosts.total))}</td>
-                <td>${html(formatCurrency(payment.totalPayment))}</td>
-                <td>${html(formatCurrency(payment.cumulativePaid))}</td>
+                <td>${escaped(String(payment.month))}</td>
+                <td>${escaped(formatCurrency(payment.escalatedPayment))}</td>
+                <td>${escaped(formatCurrency(payment.additionalCosts.total))}</td>
+                <td>${escaped(formatCurrency(payment.totalPayment))}</td>
+                <td>${escaped(formatCurrency(payment.cumulativePaid))}</td>
               </tr>
             `
               )

--- a/packages/ui/src/lib/analytics.ts
+++ b/packages/ui/src/lib/analytics.ts
@@ -99,7 +99,7 @@ class AnalyticsTracker {
     const key = 'fanalyx_session_id';
     let sessionId = sessionStorage.getItem(key);
     if (!sessionId) {
-      sessionId = `sess_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      sessionId = `sess_${crypto.randomUUID()}`;
       sessionStorage.setItem(key, sessionId);
     }
     return sessionId;
@@ -111,7 +111,7 @@ class AnalyticsTracker {
     const key = 'fanalyx_visitor_id';
     let visitorId = localStorage.getItem(key);
     if (!visitorId) {
-      visitorId = `vis_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      visitorId = `vis_${crypto.randomUUID()}`;
       localStorage.setItem(key, visitorId);
     }
     return visitorId;

--- a/workers/api/src/cron/analyze-logs.ts
+++ b/workers/api/src/cron/analyze-logs.ts
@@ -320,7 +320,6 @@ export async function handleDailyLogAnalysis(env: Env): Promise<Response> {
     return new Response(
       JSON.stringify({
         error: 'Analysis failed',
-        message: error instanceof Error ? error.message : String(error),
       }),
       { status: 500, headers: { 'Content-Type': 'application/json' } }
     );

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -291,7 +291,8 @@ export function getPreviousModelState(
   const paramMatches = modelMatch[0].match(/(\w+):\s*([^,]+)/g);
 
   if (paramMatches) {
-    paramMatches.forEach((match) => {
+    const boundedMatches = paramMatches.slice(0, 50);
+    boundedMatches.forEach((match) => {
       const [, key, value] = match.match(/(\w+):\s*([^,]+)/) || [];
       if (key && value) {
         // Try to parse as number, otherwise keep as string

--- a/workers/api/src/lib/auth.ts
+++ b/workers/api/src/lib/auth.ts
@@ -50,14 +50,17 @@ async function sha256(message: string): Promise<string> {
  */
 export function generateApiKey(isTest = false): string {
   const prefix = isTest ? 'fk_test_' : 'fk_live_';
-  const randomBytes = crypto.getRandomValues(new Uint8Array(24));
   const base62Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const maxUnbiased = Math.floor(256 / base62Chars.length) * base62Chars.length;
 
   let key = '';
-  for (let i = 0; i < 32; i++) {
-    const byte = randomBytes[i % 24];
-    if (byte !== undefined) {
-      key += base62Chars[byte % 62];
+  while (key.length < 32) {
+    const bytes = crypto.getRandomValues(new Uint8Array(32));
+    for (const byte of bytes) {
+      if (key.length >= 32) break;
+      if (byte < maxUnbiased) {
+        key += base62Chars[byte % base62Chars.length];
+      }
     }
   }
 
@@ -256,10 +259,18 @@ export async function validateApiKey(request: Request, env: Env): Promise<AuthRe
     allHeaders: Object.fromEntries(request.headers.entries()),
   });
 
+  const isTrustedFanalyxUrl = (value: string | null): boolean => {
+    if (!value) return false;
+    try {
+      const hostname = new URL(value).hostname;
+      return hostname === 'fanalyx.com' || hostname.endsWith('.fanalyx.com');
+    } catch {
+      return false;
+    }
+  };
+
   const isInternalRequest =
-    origin === 'https://fanalyx.com' ||
-    referer?.includes('fanalyx.com') ||
-    internalRequestHeader === 'true';
+    isTrustedFanalyxUrl(origin) || isTrustedFanalyxUrl(referer) || internalRequestHeader === 'true';
 
   console.log('Internal request check:', { isInternalRequest });
 

--- a/workers/api/src/lib/enhanced-mcp.ts
+++ b/workers/api/src/lib/enhanced-mcp.ts
@@ -135,7 +135,7 @@ export async function handleEnhancedMCPRequest(
       const mcpError = createMCPError(
         MCP_ERROR_CODES.INVALID_REQUEST,
         'Invalid request format',
-        error.issues
+        env.ENVIRONMENT === 'development' ? error.issues : undefined
       );
 
       logWarn(requestContext, 'MCP request validation failed', {
@@ -172,7 +172,10 @@ export async function handleEnhancedMCPRequest(
         JSON.stringify({
           jsonrpc: '2.0',
           id: 'unknown',
-          error,
+          error: {
+            code: error.code,
+            message: error.message,
+          },
         }),
         {
           status: getStatusCodeForMCPError(error.code),

--- a/workers/api/src/lib/enhanced-mcp.ts
+++ b/workers/api/src/lib/enhanced-mcp.ts
@@ -193,9 +193,7 @@ export async function handleEnhancedMCPRequest(
       errorCode: MCP_ERROR_CODES.INTERNAL_ERROR,
     };
 
-    const mcpError = createMCPError(MCP_ERROR_CODES.INTERNAL_ERROR, 'Internal server error', {
-      originalError: error instanceof Error ? error.message : String(error),
-    });
+    const mcpError = createMCPError(MCP_ERROR_CODES.INTERNAL_ERROR, 'Internal server error');
 
     logError(requestContext, new Error(error instanceof Error ? error.message : String(error)));
 

--- a/workers/api/src/lib/error-handler.ts
+++ b/workers/api/src/lib/error-handler.ts
@@ -16,12 +16,14 @@ export function withErrorHandler(handler: RouteHandler) {
       const isDevelopment = env.ENVIRONMENT === 'development';
 
       if (error && typeof error === 'object' && 'name' in error && error.name === 'ZodError') {
+        if (isDevelopment) {
+          console.error('Validation error:', error);
+        }
         return new Response(
           JSON.stringify({
             error: {
               message: 'Validation error',
               code: 'VALIDATION_ERROR',
-              ...(isDevelopment && { details: error }),
             },
           }),
           { status: 400, headers: buildDefaultHeaders(env) }
@@ -57,13 +59,15 @@ export function withErrorHandler(handler: RouteHandler) {
         }
       }
 
+      if (isDevelopment && error instanceof Error) {
+        console.error('Internal error:', error.message, error.stack);
+      }
+
       return new Response(
         JSON.stringify({
           error: {
-            message:
-              isDevelopment && error instanceof Error ? error.message : 'Internal server error',
+            message: 'Internal server error',
             code: 'INTERNAL_ERROR',
-            ...(isDevelopment && error instanceof Error && { stack: error.stack }),
           },
         }),
         { status: 500, headers: buildDefaultHeaders(env) }

--- a/workers/web/src/index.ts
+++ b/workers/web/src/index.ts
@@ -138,8 +138,7 @@ export default {
         return new Response(apiRes.body, { status: apiRes.status, headers });
       } catch (error) {
         console.error('API proxy error:', error);
-        const details = error instanceof Error ? error.message : String(error);
-        return new Response(JSON.stringify({ error: 'API proxy failed', details }), {
+        return new Response(JSON.stringify({ error: 'API proxy failed' }), {
           status: 502,
           headers: { ...defaults, 'Content-Type': 'application/json; charset=utf-8' },
         });


### PR DESCRIPTION
## Summary

- Pin third-party GitHub Actions to commit SHAs across all workflows (OpenSSF Scorecard `PinnedDependencies`).
- Scope `GITHUB_TOKEN` permissions to job level where possible (`TokenPermissions`).
- Stop Workers/R2 monitor workflows from posting hundreds of duplicate issue comments; update the open alert issue body instead.
- Require at least one PR approval on protected branches (`main`/`dev`).
- Fix CodeQL-flagged patterns: no stack/details in API error JSON, crypto-safe IDs, chat XSS via `textContent`, URL host checks, unbiased API key generation.
- Exempt `alert:workers-errors` and `alert:R2-quota` from stale bot auto-close.

## Context

- **Dependabot:** no open security alerts; recent dependency PRs already merged.
- **npm audit:** clean at moderate level.
- **Open issue #18:** stale Workers health alert with comment spam; closing after this ships.

## Test plan

- [x] `pnpm run verify` locally (pre-commit hook)
- [ ] Merge and confirm CodeQL/Scorecard alert count drops on next scheduled scan
- [ ] Close #18 with note that monitors now update issue body only
- [ ] Apply branch protection via `sync-branch-protection` if `REPO_ADMIN_TOKEN` is set


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, API error surfaces, and merge policy; low runtime behavior change but affects how PRs merge and what clients see on failures.
> 
> **Overview**
> This PR tightens **repo governance and supply-chain hygiene** while addressing **CodeQL/security findings** in app and worker code.
> 
> **GitHub & CI:** Branch protection now requires **one approving review** and **dismisses stale reviews**. Third-party Actions are **pinned to commit SHAs** in most workflows; **workflow-level `permissions` are narrowed** (e.g. CodeQL, coverage, dependabot-automerge, release) with elevated scopes only on jobs that need them. **R2 and Workers health monitors** stop appending duplicate issue comments—they **update the open alert issue body** instead. The **stale** workflow exempts `alert:workers-errors` and `alert:R2-quota` labels.
> 
> **Application security:** API/MCP/web paths **omit error details, stacks, and Zod payloads** from client JSON outside dev; **internal “fanalyx” requests** use hostname parsing instead of substring checks; **API keys** use rejection sampling for base62; model param parsing is **capped**. Chat UI renders messages with **`textContent` / pre-wrap** (no assistant `innerHTML`). Session/visitor IDs use **`crypto.randomUUID()`**. Sitemap homepage detection uses **parsed URL hostname/path**.
> 
> **Minor:** Astro sitemap homepage logic; lease PDF export renames escape helper only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5917c2b509cbfac27066dd36b802deeb96616c22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sanitized chat rendering to prevent HTML injection.
  * Hardened API key generation and refined internal-request checks.
  * Removed sensitive error details from API responses and internal handlers.
  * Ensured PDF/exported reports escape content.

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs across workflows.
  * Tightened branch protection to require approving reviews and dismiss stale reviews.
  * Switched session/visitor IDs to cryptographically generated UUIDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->