### PR TITLE
fix(ci): correct CodeQL action SHAs for Scorecard SARIF upload

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/init@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4
+        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
         with:
           languages: javascript-typescript
 
@@ -67,4 +67,4 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/analyze@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4
+        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/init@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4
         with:
           languages: javascript-typescript
 
@@ -67,4 +67,4 @@ jobs:
             steps.skip.outputs.skip_ci != 'true' &&
             steps.paths.outputs.code == 'true'
           )
-        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/analyze@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
       code_changed: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Detect skip-ci label
         id: skip
@@ -31,7 +31,7 @@ jobs:
 
       - name: Detect non-doc code changes
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: .github/path-filters.yml
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check for duplicate files
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
@@ -68,11 +68,11 @@ jobs:
 
       - name: Checkout
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency review
         if: needs.gate.outputs.skip_ci != 'true' && needs.gate.outputs.code_changed == 'true'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
@@ -88,12 +88,12 @@ jobs:
 
       - name: Checkout
         if: needs.gate.outputs.skip_ci != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: TruffleHog OSS
         if: needs.gate.outputs.skip_ci != 'true'
-        uses: trufflesecurity/trufflehog@v3.95.3
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
         with:
           extra_args: --only-verified

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/upload-sarif@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Use the correct `github/codeql-action` v4 release commit (`f0489ab…`) for `init`, `analyze`, and `upload-sarif` (fixes Scorecard "imposter commit" verification failure).
- Finish pinning Actions in `pull-request.yml` that were still on floating tags.

## Test plan

- [ ] CI + CodeQL green
- [ ] Manually trigger OpenSSF Scorecard after merge; SARIF upload should succeed


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pinning with no application or auth logic changes; main risk is CI mis-pinning if a SHA were wrong, which this PR explicitly corrects for CodeQL.
> 
> **Overview**
> Updates GitHub Actions to **pin by commit SHA** instead of floating version tags, and fixes a **wrong CodeQL v4 SHA** that was breaking OpenSSF Scorecard SARIF upload verification (“imposter commit”).
> 
> In **`codeql.yml`** and **`scorecard.yml`**, `github/codeql-action` **init**, **analyze**, and **upload-sarif** now use commit `f0489ab…` (labeled v4). In **`pull-request.yml`**, remaining unpinned steps are pinned: **checkout** v6, **paths-filter** v4, **dependency-review-action** v5, and **trufflehog** v3.95.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746f6cc75a63de22a90bddcee95e7fa735b5eb24. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned versions of GitHub Actions used for code analysis and security scanning across CI/CD workflows, including CodeQL analysis, dependency review, and secret detection tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->