### PR TITLE
fix(ci): Scorecard upload-sarif pin with runtime entrypoints

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b # v4
+        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Use dc73d59 for upload-sarif (f0489ab missing entry JS).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency pin change with no application or security logic impact.
> 
> **Overview**
> The OpenSSF Scorecard workflow’s **Upload SARIF** step now pins `github/codeql-action/upload-sarif` to commit `dc73d59` instead of `f0489ab`, matching the pins already used in `codeql.yml` for init/analyze.
> 
> This fixes a broken Scorecard run where the previous pin lacked the action’s runtime entry JavaScript, so SARIF upload could fail after analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909a9ae03b76b4e32ef4d8d18bb459e7efa365cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->