### PR TITLE
fix(ci): Scorecard SARIF to GitHub Security tab only

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,8 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          # GitHub Security tab only (webapp publish fails SHA verification for codeql-action pins).
+          publish_results: false
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4


### PR DESCRIPTION
Set publish_results: false to avoid Scorecard webapp SHA verification failure; SARIF still uploads via codeql-action/upload-sarif@v4.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow flag change; security reporting path is narrowed, not removed.
> 
> **Overview**
> Disables OpenSSF Scorecard’s **webapp** result publishing (`publish_results: false`) so the workflow no longer fails SHA verification against pinned `codeql-action` refs.
> 
> **SARIF upload is unchanged** — `github/codeql-action/upload-sarif` still sends `results.sarif` to the repo **Security** tab (Code scanning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4018fb4af35368006e3ebc40d428b6bfe8f35e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->