### PR TITLE
docs(security): maintainer code-scanning hygiene log

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -60,6 +60,8 @@ Default required checks: **PR gate**, **Secret scan**, **CI gate**, **Build and 
 
 Optional: add the repo to the [OpenSSF Scorecard dashboard](https://scorecard.dev/) for public score tracking.
 
+**Hygiene log:** [docs/SECURITY_HYGIENE.md](../docs/SECURITY_HYGIENE.md) — remediation PR history, remaining policy alerts (`CodeReviewID`, `CIIBestPracticesID`, `SASTID`), and re-run commands.
+
 ## 6. Deploy and monitors
 
 | Secret / setting | Used by |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ pnpm run dev           # Astro build + web worker (8788) + API (8787)
 - **Workflow map:** [.github/workflows/README.md](.github/workflows/README.md)
 - **Maintainer setup:** [.github/MAINTAINER_SETUP.md](.github/MAINTAINER_SETUP.md) (Codecov, Dependabot workflows, branch protection sync)
 - **`main` push only:** `ci-cd.yml` (artifacts)
-- **Security:** OpenSSF Scorecard in `scorecard.yml` (weekly + Security tab SARIF)
+- **Security:** OpenSSF Scorecard in `scorecard.yml` (weekly + Security tab SARIF); maintainer log in [docs/SECURITY_HYGIENE.md](./docs/SECURITY_HYGIENE.md)
 - **Never commit:** Finder duplicates (`file 2`), flat Playwright specs, or `tests/utils/nav.ts` (use `tests/_shared/`)
 
 ## Before opening a PR

--- a/docs/SECURITY_HYGIENE.md
+++ b/docs/SECURITY_HYGIENE.md
@@ -1,0 +1,81 @@
+# Security hygiene (maintainers)
+
+Living record of code-scanning remediation for **blakeox/financial-analysis**. For vulnerability reporting, see [SECURITY.md](../SECURITY.md). For CI setup, see [.github/MAINTAINER_SETUP.md](../.github/MAINTAINER_SETUP.md).
+
+## Current posture (2026-05-26)
+
+| Metric | Status |
+|--------|--------|
+| Open **CodeQL** (JavaScript/TypeScript) alerts | **0** |
+| Open **Scorecard policy** alerts | **2** (organizational / process; no file path) |
+| Dependabot | Enabled; patch/minor auto-merge via workflow |
+| CodeQL workflow | [.github/workflows/codeql.yml](../.github/workflows/codeql.yml) |
+| OpenSSF Scorecard | [.github/workflows/scorecard.yml](../.github/workflows/scorecard.yml) → SARIF on Security tab |
+
+### Remaining open alerts (Scorecard policy)
+
+These are **not** fixable by a single code change. They reflect OpenSSF Scorecard checks uploaded as SARIF (same severity as CodeQL in the Security tab).
+
+| Alert | Rule ID | Why it remains | Practical remediation |
+|-------|---------|----------------|----------------------|
+| Code-Review | `CodeReviewID` | Scorecard inspects ~30 recent merges for **human** approvals. Solo-maintainer merges (temporary `required_approving_review_count: 0` via [branch-protection sync](../scripts/sync-branch-protection.mjs)) do not satisfy “second person reviewed.” | Add a second maintainer/reviewer for security-sensitive PRs; keep branch protection at **1** required review when not self-merging. |
+| CII Best Practices | `CIIBestPracticesID` | No [OpenSSF Best Practices](https://www.bestpractices.dev/) badge on the repo. | Enroll at bestpractices.dev and work toward **passing** (documented process). |
+| ~~SAST~~ | `SASTID` | **Dismissed (false positive, 2026-05-26):** CodeQL is configured; Scorecard reported “27/30 commits” with SAST because doc-only / path-filter skips do not run analyze on every commit. | No action unless alert reopens after Scorecard upload. |
+
+## Remediation timeline (merged PRs)
+
+| PR | Focus |
+|----|--------|
+| [#302](https://github.com/blakeox/financial-analysis/pull/302) | Pinned Actions SHAs, scoped `GITHUB_TOKEN`, monitor workflow hygiene, branch protection review count, API/chat hardening |
+| [#303](https://github.com/blakeox/financial-analysis/pull/303)–[#306](https://github.com/blakeox/financial-analysis/pull/306) | CodeQL init/analyze SHA pins; Scorecard SARIF-only upload (`publish_results: false`) |
+| [#307](https://github.com/blakeox/financial-analysis/pull/307) | Error handler, validation (markers vs regex), chat HTML escape, analytics stack removal, auth hosts |
+| [#311](https://github.com/blakeox/financial-analysis/pull/311) | Safe logging (no raw `Error` objects), MCP responses without Zod issue leakage, marker threat detection, auth hostname checks, sitemap pathname parsing |
+| [#313](https://github.com/blakeox/financial-analysis/pull/313) | `advanced-security` marker detectors; API validation = control-char strip only |
+| [#314](https://github.com/blakeox/financial-analysis/pull/314) | Lease print export: DOM `textContent` / JSON in `<pre>` instead of `document.write` HTML |
+
+**Alert count trajectory:** ~90 open → ~31 → 14 → 8 → 3 → **2** open policy (`CodeReviewID`, `CIIBestPracticesID`).
+
+## Code patterns introduced (for future PRs)
+
+- **Logging:** log `error.message` (and safe fields), not full `Error` / stack in production paths (`workers/api/src/lib/request-context.ts`, error handler).
+- **API keys:** unbiased hex from `crypto.getRandomValues` (`workers/api/src/lib/auth.ts`).
+- **Auth hosts:** `fanalyx.com` and single-label `*.fanalyx.com` via hostname **label count**, not `endsWith` alone.
+- **Validation:** `stripControlCharacters` + marker-based `detectThreats` in `workers/api/src/lib/validation.ts` (avoid ReDoS-prone regex chains).
+- **Web advanced-security:** detector functions, not `RegExp`, in `apps/web/src/scripts/_shared/advanced-security.ts`.
+- **Chat UI:** `textContent` / escaped labels in `chat-panel.ts`; avoid `innerHTML` with user content.
+- **Same-origin links:** `toSafeSameOriginHref()` for mortgage scenario exports.
+
+## Dismissals (stale / false positive)
+
+Many historical alerts were dismissed after merge to `main` when:
+
+- Line numbers pointed at **old** code already fixed on `main`.
+- CodeQL flagged safe APIs (`textContent`, `crypto.randomUUID()`).
+- Scorecard duplicated checks already satisfied by branch protection or CodeQL.
+
+Use GitHub’s **Dismiss alert** with a short rationale; prefer **false positive** only after verifying current `main`.
+
+## Re-run scans
+
+```bash
+gh workflow run "CodeQL" --ref main
+gh workflow run "OpenSSF Scorecard" --ref main
+gh api 'repos/blakeox/financial-analysis/code-scanning/alerts?state=open&per_page=100' \
+  --jq '[.[] | {number, rule: .rule.id, path: .most_recent_instance.location.path}]'
+```
+
+## Solo-maintainer merge workflow
+
+Branch protection requires **1** approving review on `main` / `dev`. To merge your own security PRs:
+
+1. `node scripts/sync-branch-protection.mjs` (sets review count from [.github/branch-protection.json](../.github/branch-protection.json), temporarily `0` if configured for merge).
+2. Merge when CI is green.
+3. Restore `required_approving_review_count: 1` and sync again.
+
+This unblocks delivery but **hurts** Scorecard **Code-Review** until a second human reviewer participates.
+
+## Related docs
+
+- [SECURITY.md](../SECURITY.md) — reporting vulnerabilities
+- [PHASE2_SECURITY_IMPROVEMENTS.md](./PHASE2_SECURITY_IMPROVEMENTS.md) / [PHASE3_SECURITY_IMPROVEMENTS.md](./PHASE3_SECURITY_IMPROVEMENTS.md) — feature-era security notes
+- [CHAT_SECURITY_ROADMAP.md](./CHAT_SECURITY_ROADMAP.md) — chat-specific roadmap


### PR DESCRIPTION
## Summary

- Adds [docs/SECURITY_HYGIENE.md](docs/SECURITY_HYGIENE.md) documenting the #302–#314 remediation series, alert count trajectory, code patterns to preserve, and triage for remaining Scorecard policy checks.
- Links the doc from `AGENTS.md` and `.github/MAINTAINER_SETUP.md`.

## Context

All file-level CodeQL alerts are cleared on `main`. Two open policy alerts remain (`CodeReviewID`, `CIIBestPracticesID`). `SASTID` was dismissed as false positive (CodeQL configured; Scorecard partial commit coverage).

## Test plan

- [x] Doc-only change; pre-commit hooks passed locally
- [ ] CI doc-only fast path (if applicable)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or CI behavior changes.
> 
> **Overview**
> Adds **`docs/SECURITY_HYGIENE.md`**, a maintainer-facing log of code-scanning remediation: current posture (0 open CodeQL, 2 Scorecard policy alerts), PR #302–#314 timeline, patterns to preserve in future changes, dismissal guidance, `gh` re-run commands, and solo-maintainer branch-protection merge notes.
> 
> **`AGENTS.md`** and **`.github/MAINTAINER_SETUP.md`** now link to that doc from the Security / OpenSSF Scorecard sections so agents and maintainers can find the hygiene log without searching the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78031bb60286566cfdcd5ab9b68a4bb1955b8713. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security hygiene and maintainer workflow documentation to track security posture metrics, remediation history, and code security patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->