### PR TITLE
docs(security): openssf best practices enrollment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Advanced financial analysis tooling with LLM-powered insights, built with modern
 
 ## Open Source
 
-This project is open source under the [MIT License](./LICENSE). Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md). Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) and [Security Policy](./SECURITY.md) before participating.
+This project is open source under the [MIT License](./LICENSE). Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md). Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) and [Security Policy](./SECURITY.md) before participating. Maintainers: [security hygiene log](./docs/SECURITY_HYGIENE.md) and [OpenSSF Best Practices enrollment](./docs/OPENSSF_BEST_PRACTICES.md).
 
 ## 🚀 Features
 
@@ -466,6 +466,8 @@ Note on COMMIT_SHA:
 - [Deployment Guide](./docs/DEPLOYMENT.md)
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Security Policy](./SECURITY.md)
+- [Security hygiene (maintainers)](./docs/SECURITY_HYGIENE.md)
+- [OpenSSF Best Practices enrollment](./docs/OPENSSF_BEST_PRACTICES.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Agent Guidelines](./AGENT.md)
 - [Environment Setup](./.env.example)

--- a/docs/OPENSSF_BEST_PRACTICES.md
+++ b/docs/OPENSSF_BEST_PRACTICES.md
@@ -1,0 +1,51 @@
+# OpenSSF Best Practices badge (enrollment)
+
+Guide for clearing Scorecard alert `CIIBestPracticesID` by enrolling **financial-analysis** at [OpenSSF Best Practices](https://www.bestpractices.dev/).
+
+## Enroll the project
+
+1. Sign in at [bestpractices.dev](https://www.bestpractices.dev/) (GitHub OAuth).
+2. **Create project** → [New project](https://www.bestpractices.dev/en/projects/new).
+3. Set **Project URL** to: `https://github.com/blakeox/financial-analysis`
+4. Work through the questionnaire; use the evidence table below for quick answers.
+5. When criteria are satisfied, request **passing** (then silver/gold if desired).
+6. Add the badge to [README.md](../README.md) (replace `PROJECT_ID`):
+
+   ```markdown
+   [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/PROJECT_ID/badge)](https://www.bestpractices.dev/projects/PROJECT_ID)
+   ```
+
+7. Re-run Scorecard on `main` (see [SECURITY_HYGIENE.md](./SECURITY_HYGIENE.md#re-run-scans)).
+
+## Evidence map (passing tier)
+
+Most items are satisfied today; confirm wording on the site matches current `main`.
+
+| Topic | Status | Evidence in repo |
+|-------|--------|------------------|
+| Public repo | Yes | `https://github.com/blakeox/financial-analysis` |
+| License | MIT | [LICENSE](../LICENSE) |
+| Version control | GitHub | Default branch `main` |
+| Build / CI | Yes | [.github/workflows/ci.yml](../.github/workflows/ci.yml), README CI badge |
+| Tests | Yes | `pnpm run verify`, Vitest in packages/workers, Playwright e2e |
+| Code review | Policy | [.github/branch-protection.json](../.github/branch-protection.json) — **1** required approval on `main` / `dev` |
+| Vulnerability reporting | Yes | [SECURITY.md](../SECURITY.md) |
+| CoC | Yes | [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) |
+| Contributing guide | Yes | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Dependency updates | Yes | [.github/dependabot.yml](../.github/dependabot.yml), dependabot-automerge workflow |
+| Static analysis (SAST) | Yes | [.github/workflows/codeql.yml](../.github/workflows/codeql.yml) |
+| Supply-chain posture | Yes | [.github/workflows/scorecard.yml](../.github/workflows/scorecard.yml), pinned Actions SHAs |
+| No committed secrets | Policy | [CONTRIBUTING.md](../CONTRIBUTING.md#security--privacy), CI secret scan |
+| Release / versioning | Partial | Tags/releases as you ship; document in questionnaire if not semver-tagged yet |
+
+## Maintainer notes
+
+- **Solo maintainer:** Code review is enforced in branch protection; Scorecard `CodeReviewID` may still flag recent merges without a second human approver — see [SECURITY_HYGIENE.md](./SECURITY_HYGIENE.md).
+- **Doc-only PRs:** CodeQL and heavy CI steps may skip; SAST is still configured (see dismissed `SASTID` note in hygiene doc).
+- **Badge API:** Scorecard reads the Best Practices API; the badge must be **passing** (or in-progress, for partial credit) on the project URL.
+
+## After passing
+
+1. Add README badge (snippet above).
+2. Update [SECURITY_HYGIENE.md](./SECURITY_HYGIENE.md) — set open policy alerts to **0** or dismiss stale `CIIBestPracticesID` if the alert lingers one Scorecard run.
+3. Optional: list the project on [scorecard.dev](https://scorecard.dev/) (already have README Scorecard badge).

--- a/docs/SECURITY_HYGIENE.md
+++ b/docs/SECURITY_HYGIENE.md
@@ -7,7 +7,7 @@ Living record of code-scanning remediation for **blakeox/financial-analysis**. F
 | Metric | Status |
 |--------|--------|
 | Open **CodeQL** (JavaScript/TypeScript) alerts | **0** |
-| Open **Scorecard policy** alerts | **2** (organizational / process; no file path) |
+| Open **Scorecard policy** alerts | **1** (`CIIBestPracticesID`; enroll via [OPENSSF_BEST_PRACTICES.md](./OPENSSF_BEST_PRACTICES.md)) |
 | Dependabot | Enabled; patch/minor auto-merge via workflow |
 | CodeQL workflow | [.github/workflows/codeql.yml](../.github/workflows/codeql.yml) |
 | OpenSSF Scorecard | [.github/workflows/scorecard.yml](../.github/workflows/scorecard.yml) → SARIF on Security tab |
@@ -18,7 +18,7 @@ These are **not** fixable by a single code change. They reflect OpenSSF Scorecar
 
 | Alert | Rule ID | Why it remains | Practical remediation |
 |-------|---------|----------------|----------------------|
-| Code-Review | `CodeReviewID` | Scorecard inspects ~30 recent merges for **human** approvals. Solo-maintainer merges (temporary `required_approving_review_count: 0` via [branch-protection sync](../scripts/sync-branch-protection.mjs)) do not satisfy “second person reviewed.” | Add a second maintainer/reviewer for security-sensitive PRs; keep branch protection at **1** required review when not self-merging. |
+| ~~Code-Review~~ | `CodeReviewID` | **Dismissed (won’t fix, 2026-05-26):** Solo-maintainer; branch protection still requires **1** approval on `main`/`dev`. Scorecard’s ~30-merge heuristic flags emergency self-merges documented below. | Add a second maintainer if you want Scorecard green without dismissal. |
 | CII Best Practices | `CIIBestPracticesID` | No [OpenSSF Best Practices](https://www.bestpractices.dev/) badge on the repo. | Enroll at bestpractices.dev and work toward **passing** (documented process). |
 | ~~SAST~~ | `SASTID` | **Dismissed (false positive, 2026-05-26):** CodeQL is configured; Scorecard reported “27/30 commits” with SAST because doc-only / path-filter skips do not run analyze on every commit. | No action unless alert reopens after Scorecard upload. |
 
@@ -33,7 +33,7 @@ These are **not** fixable by a single code change. They reflect OpenSSF Scorecar
 | [#313](https://github.com/blakeox/financial-analysis/pull/313) | `advanced-security` marker detectors; API validation = control-char strip only |
 | [#314](https://github.com/blakeox/financial-analysis/pull/314) | Lease print export: DOM `textContent` / JSON in `<pre>` instead of `document.write` HTML |
 
-**Alert count trajectory:** ~90 open → ~31 → 14 → 8 → 3 → **2** open policy (`CodeReviewID`, `CIIBestPracticesID`).
+**Alert count trajectory:** ~90 open → ~31 → 14 → 8 → 3 → 2 → **1** open policy (`CIIBestPracticesID`; `CodeReviewID` dismissed).
 
 ## Code patterns introduced (for future PRs)
 
@@ -76,6 +76,7 @@ This unblocks delivery but **hurts** Scorecard **Code-Review** until a second hu
 
 ## Related docs
 
+- [OPENSSF_BEST_PRACTICES.md](./OPENSSF_BEST_PRACTICES.md) — badge enrollment checklist (clears `CIIBestPracticesID`)
 - [SECURITY.md](../SECURITY.md) — reporting vulnerabilities
 - [PHASE2_SECURITY_IMPROVEMENTS.md](./PHASE2_SECURITY_IMPROVEMENTS.md) / [PHASE3_SECURITY_IMPROVEMENTS.md](./PHASE3_SECURITY_IMPROVEMENTS.md) — feature-era security notes
 - [CHAT_SECURITY_ROADMAP.md](./CHAT_SECURITY_ROADMAP.md) — chat-specific roadmap


### PR DESCRIPTION
## Summary

- Adds [docs/OPENSSF_BEST_PRACTICES.md](docs/OPENSSF_BEST_PRACTICES.md) with enrollment steps and an evidence map for the passing-tier questionnaire.
- Updates [docs/SECURITY_HYGIENE.md](docs/SECURITY_HYGIENE.md) for `CodeReviewID` dismissal and single remaining policy alert.
- Links both docs from [README.md](README.md).

## Context

`CodeReviewID` dismissed on the Security tab (won’t fix — solo maintainer, branch protection still requires 1 review). Only `CIIBestPracticesID` remains open until badge enrollment.

## Test plan

- [x] Doc-only; hooks passed locally
- [ ] Merge after CI green


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or deployment impact.
> 
> **Overview**
> Adds maintainer documentation for clearing the remaining OpenSSF Scorecard policy alert **`CIIBestPracticesID`** via [bestpractices.dev](https://www.bestpractices.dev/) enrollment.
> 
> **`docs/OPENSSF_BEST_PRACTICES.md`** is new: step-by-step enrollment, a passing-tier **evidence map** (CI, tests, CodeQL, branch protection, etc.), README badge snippet, and post-passing follow-ups.
> 
> **`docs/SECURITY_HYGIENE.md`** now records **`CodeReviewID`** as dismissed (won’t fix — solo maintainer), counts **one** open policy alert (`CIIBestPracticesID`), updates the alert trajectory, and links the enrollment guide under Related docs.
> 
> **`README.md`** points maintainers at the hygiene log and enrollment doc in the Open Source blurb and Documentation list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2901c51de2e2d756b5f7f799f79bd2dc5c969ea7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->