### PR TITLE
fix(ci): local pr-path-labeler for flaky actions/labeler

### DIFF
--- a/.github/actions/pr-path-labeler/action.yml
+++ b/.github/actions/pr-path-labeler/action.yml
@@ -1,0 +1,48 @@
+name: PR path labeler
+description: Apply path-based PR labels (replaces actions/labeler when codeload downloads fail)
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        PR="${{ github.event.pull_request.number }}"
+        BASE="${{ github.event.pull_request.base.sha }}"
+
+        if ! git rev-parse "$BASE^{commit}" >/dev/null 2>&1; then
+          echo "::error::Base commit unavailable; set fetch-depth: 0 on actions/checkout"
+          exit 1
+        fi
+
+        mapfile -t files < <(git diff --name-only "$BASE" HEAD)
+        declare -A labels=()
+
+        for f in "${files[@]}"; do
+          [[ -z "$f" ]] && continue
+          case "$f" in
+            apps/web/*|packages/ui/*) labels[frontend]=1 ;;
+          esac
+          case "$f" in
+            workers/*) labels[backend]=1 ;;
+          esac
+          case "$f" in
+            packages/analysis/*) labels[analysis]=1 ;;
+          esac
+          case "$f" in
+            packages/tools/*) labels[tools]=1 ;;
+          esac
+          case "$f" in
+            .github/workflows/*|.github/actions/*) labels[github-actions]=1 ;;
+          esac
+        done
+
+        if [[ ${#labels[@]} -eq 0 ]]; then
+          echo "No path labels to apply."
+          exit 0
+        fi
+
+        joined=$(IFS=,; echo "${!labels[*]}")
+        echo "Applying labels: $joined"
+        gh pr edit "$PR" --repo "${{ github.repository }}" --add-label "$joined"

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,4 +1,4 @@
-# Shared filters for dorny/paths-filter (ci.yml, pull-request.yml).
+# Shared path rules for repo-path-filter (ci.yml, pull-request.yml).
 # Doc-only paths align with ci.yml push paths-ignore.
 code:
   - '**'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,9 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Apply path-based labels
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          sync-labels: true
+        uses: ./.github/actions/pr-path-labeler


### PR DESCRIPTION
## Summary

- Replaces `actions/labeler` (intermittent codeload download failures) with `.github/actions/pr-path-labeler` using `gh pr edit`.
- Adds `fetch-depth: 0` on checkout for PR base diff.
- Rules match [.github/labeler.yml](.github/labeler.yml).

## Test plan

- [ ] `label` workflow passes on this PR
- [ ] Required CI checks green


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only labeling workflow; no application runtime or auth/data paths change, though labels are add-only (no sync-labels) unlike the previous action.
> 
> **Overview**
> Replaces the third-party **`actions/labeler`** step in the PR labeler workflow with a **repo-local composite action** (`.github/actions/pr-path-labeler`) so labeling no longer depends on downloading that action from codeload.
> 
> The new action diffs changed files between the PR base SHA and `HEAD`, maps paths to the same labels as `.github/labeler.yml` (`frontend`, `backend`, `analysis`, `tools`, `github-actions`), and applies them via **`gh pr edit --add-label`**. Checkout now uses **`fetch-depth: 0`** so the base commit is available for that diff.
> 
> A comment in `.github/path-filters.yml` is updated to refer to **repo-path-filter** instead of dorny/paths-filter (no rule changes in that file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a007db69c4498b76b03266eb52504f02fb3dba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request labeling automation in CI/CD workflows by consolidating and optimizing internal path-based labeling processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->