### PR TITLE
docs(security): openssf enrollment quickstart

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
+# Implemented by .github/actions/pr-path-labeler (see pr-labeler.yml).
 frontend:
   - changed-files:
       - any-glob-to-any-file: 'apps/web/**'

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Note on COMMIT_SHA:
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Security Policy](./SECURITY.md)
 - [Security hygiene (maintainers)](./docs/SECURITY_HYGIENE.md)
-- [OpenSSF Best Practices enrollment](./docs/OPENSSF_BEST_PRACTICES.md)
+- [OpenSSF Best Practices enrollment](./docs/OPENSSF_BEST_PRACTICES.md) — [quickstart](./docs/OPENSSF_ENROLLMENT_QUICKSTART.md) (clears last Security policy alert)
 - [OpenSSF Best Practices questionnaire](./docs/OPENSSF_BEST_PRACTICES_QUESTIONNAIRE.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Agent Guidelines](./AGENT.md)

--- a/docs/OPENSSF_BEST_PRACTICES.md
+++ b/docs/OPENSSF_BEST_PRACTICES.md
@@ -13,6 +13,8 @@ Exit **0** when a passing, silver, or gold badge exists for this repo; **1** if 
 
 **Tracking:** [GitHub issue #318](https://github.com/blakeox/financial-analysis/issues/318)
 
+**Quick path:** [OPENSSF_ENROLLMENT_QUICKSTART.md](./OPENSSF_ENROLLMENT_QUICKSTART.md) (~10 minutes, requires your GitHub login).
+
 ## Enroll the project
 
 1. Sign in at [bestpractices.dev](https://www.bestpractices.dev/) (GitHub OAuth) — **Log in with GitHub** on [New project](https://www.bestpractices.dev/en/projects/new).

--- a/docs/OPENSSF_ENROLLMENT_QUICKSTART.md
+++ b/docs/OPENSSF_ENROLLMENT_QUICKSTART.md
@@ -1,0 +1,40 @@
+# OpenSSF Best Practices — 10-minute quickstart
+
+Clears Security alert `CIIBestPracticesID` (#84). Full detail: [OPENSSF_BEST_PRACTICES_QUESTIONNAIRE.md](./OPENSSF_BEST_PRACTICES_QUESTIONNAIRE.md).
+
+## Steps
+
+1. Open [Create project](https://www.bestpractices.dev/en/projects/new) → **Log in with GitHub** (browser must be you; agents cannot OAuth for you).
+
+2. **Project URL:** `https://github.com/blakeox/financial-analysis`
+
+3. **Homepage URL:** same as project URL (README is the site description).
+
+4. **License:** MIT — link `https://github.com/blakeox/financial-analysis/blob/main/LICENSE`
+
+5. Work through the **passing** criteria using the [questionnaire cheat sheet](./OPENSSF_BEST_PRACTICES_QUESTIONNAIRE.md). Most answers are already satisfied (CI, CodeQL, SECURITY.md, CONTRIBUTING.md, `v0.1.1` release).
+
+6. **Submit** and request **passing** review on the site.
+
+7. Copy **project ID** from the badge URL: `https://www.bestpractices.dev/projects/<ID>/`
+
+8. Add to [README.md](../README.md) (after the Scorecard badge line):
+
+   ```markdown
+   [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/PROJECT_ID/badge)](https://www.bestpractices.dev/projects/PROJECT_ID)
+   ```
+
+9. Verify locally:
+
+   ```bash
+   pnpm run check:openssf-badge   # exit 0 when passing/silver/gold
+   gh workflow run "OpenSSF Scorecard" --ref main
+   ```
+
+10. Close [issue #318](https://github.com/blakeox/financial-analysis/issues/318). Dismiss alert #84 on the Security tab if it remains after one Scorecard run.
+
+## Verify enrollment anytime
+
+```bash
+pnpm run check:openssf-badge
+```


### PR DESCRIPTION
## Summary

- Adds [docs/OPENSSF_ENROLLMENT_QUICKSTART.md](docs/OPENSSF_ENROLLMENT_QUICKSTART.md) for clearing the last Security policy alert.
- Links from README and OPENSSF_BEST_PRACTICES; status comment on #318.

## Test plan

- [x] Doc-only

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **`docs/OPENSSF_ENROLLMENT_QUICKSTART.md`**, a short maintainer walkthrough for enrolling on [bestpractices.dev](https://www.bestpractices.dev/), adding the README badge, running `pnpm run check:openssf-badge`, and closing issue **#318** / clearing Security alert **`CIIBestPracticesID`**.
> 
> **`README.md`** and **`docs/OPENSSF_BEST_PRACTICES.md`** now point at that quickstart (README notes it clears the last Security policy alert). **`.github/labeler.yml`** gets a one-line comment that path labeling is implemented by the custom PR path labeler action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57eceb7d717118e003712f8aac65064920d2176. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->