### PR TITLE
chore(security): add apply:openssf-badge after enrollment

### DIFF
--- a/docs/OPENSSF_ENROLLMENT_QUICKSTART.md
+++ b/docs/OPENSSF_ENROLLMENT_QUICKSTART.md
@@ -18,10 +18,10 @@ Clears Security alert `CIIBestPracticesID` (#84). Full detail: [OPENSSF_BEST_PRA
 
 7. Copy **project ID** from the badge URL: `https://www.bestpractices.dev/projects/<ID>/`
 
-8. Add to [README.md](../README.md) (after the Scorecard badge line):
+8. Add the README badge (after the Scorecard line), or run:
 
-   ```markdown
-   [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/PROJECT_ID/badge)](https://www.bestpractices.dev/projects/PROJECT_ID)
+   ```bash
+   pnpm run apply:openssf-badge
    ```
 
 9. Verify locally:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "verify": "pnpm run check:duplicates && pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test",
     "check:duplicates": "node scripts/check-repo-duplicates.mjs",
     "check:openssf-badge": "node scripts/check-openssf-badge.mjs",
+    "apply:openssf-badge": "node scripts/apply-openssf-badge.mjs",
     "report:knip": "knip --no-exit-code",
     "report:knip:production": "knip --production --no-exit-code",
     "check:duplicates:files": "node scripts/check-repo-duplicates.mjs --files-only",

--- a/scripts/apply-openssf-badge.mjs
+++ b/scripts/apply-openssf-badge.mjs
@@ -13,10 +13,19 @@ const root = join(__dirname, '..');
 const readmePath = join(root, 'README.md');
 const dryRun = process.argv.includes('--dry-run');
 
-const raw = execFileSync('node', ['scripts/check-openssf-badge.mjs', '--json'], {
-  cwd: root,
-  encoding: 'utf8',
-});
+let raw;
+try {
+  raw = execFileSync('node', ['scripts/check-openssf-badge.mjs', '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+} catch (error) {
+  if (typeof error?.stdout === 'string' && error.stdout.trim()) {
+    raw = error.stdout;
+  } else {
+    throw error;
+  }
+}
 const { project } = JSON.parse(raw);
 if (!project?.id) {
   console.error('No enrolled project at passing tier. Run: pnpm run check:openssf-badge');

--- a/scripts/apply-openssf-badge.mjs
+++ b/scripts/apply-openssf-badge.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * After passing-tier enrollment on bestpractices.dev, add the README badge line.
+ * Usage: node scripts/apply-openssf-badge.mjs [--dry-run]
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const readmePath = join(root, 'README.md');
+const dryRun = process.argv.includes('--dry-run');
+
+const raw = execFileSync('node', ['scripts/check-openssf-badge.mjs', '--json'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+const { project } = JSON.parse(raw);
+if (!project?.id) {
+  console.error('No enrolled project at passing tier. Run: pnpm run check:openssf-badge');
+  process.exit(1);
+}
+
+const id = project.id;
+const badgeLine = `[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/${id}/badge)](https://www.bestpractices.dev/projects/${id})`;
+const readme = readFileSync(readmePath, 'utf8');
+
+if (readme.includes('bestpractices.dev/projects/')) {
+  console.log(`README already references Best Practices (project id=${id}).`);
+  process.exit(0);
+}
+
+const anchor = '![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/blakeox/financial-analysis/badge)';
+if (!readme.includes(anchor)) {
+  console.error('Could not find Scorecard badge line in README.md');
+  process.exit(1);
+}
+
+const updated = readme.replace(
+  anchor,
+  `${anchor}\n${badgeLine}`
+);
+
+if (dryRun) {
+  console.log('Would insert after Scorecard badge:\n', badgeLine);
+  process.exit(0);
+}
+
+writeFileSync(readmePath, updated);
+console.log(`Added Best Practices badge (project id=${id}).`);
+console.log('Next: pnpm run verify && open PR, then gh workflow run "OpenSSF Scorecard" --ref main');


### PR DESCRIPTION
## Summary
- Adds `pnpm run apply:openssf-badge` to insert the README badge after passing-tier enrollment on bestpractices.dev.
- Updates enrollment quickstart to reference the script.

## Test plan
- [x] `pnpm run verify` locally
- [ ] CI green
- After maintainer enrolls: `pnpm run apply:openssf-badge` then follow-up PR for README badge (closes #318)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small maintainer-only README automation script; no runtime product or auth changes.
> 
> **Overview**
> Adds **`pnpm run apply:openssf-badge`**, which looks up the enrolled Best Practices project via the existing `check-openssf-badge` JSON output and inserts the README badge line immediately after the OpenSSF Scorecard badge (with `--dry-run` and skip-if-already-present behavior).
> 
> The OpenSSF enrollment quickstart now points maintainers at that command instead of pasting markdown by hand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de17b83cccbf60da184223e3dc0f665ad4b1fe8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated command to insert an OpenSSF Best Practices badge into project READMEs, with a dry-run option to preview changes and safeguards against duplicate or misplaced insertions.

* **Documentation**
  * Updated the OpenSSF enrollment quickstart to document both manual badge placement and the new automated badge-apply command, plus guidance for local verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/financial-analysis/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->